### PR TITLE
Add Simplified Chinese (zh-CN) localization support

### DIFF
--- a/StringResources_CN.xaml
+++ b/StringResources_CN.xaml
@@ -1,0 +1,2085 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:system="clr-namespace:System;assembly=mscorlib">
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="../Styles/FlowDocument.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+
+    <!-- Display Profiles Window Bar -->
+    <system:String x:Key="Monitor">显示器</system:String>
+    <system:String x:Key="Projector">投影仪</system:String>
+    <system:String x:Key="TV">电视</system:String>
+    <system:String x:Key="VrHeadset">VR 头显</system:String>
+
+    <!-- Misc -->
+    <system:String x:Key="LoadingApplication">正在加载应用程序。请稍候...</system:String>
+    <system:String x:Key="SwitchToCompactGui">切换到紧凑型界面。</system:String>
+    <system:String x:Key="SwitchToNormalGui">切换到普通界面。</system:String>
+    <system:String x:Key="MinimizeToTray">最小化到系统托盘。</system:String>
+    <system:String x:Key="ChangeLanguage">更改语言</system:String>
+    <system:String x:Key="Close">关闭</system:String>
+    <system:String x:Key="Show">显示</system:String>
+    <system:String x:Key="Enable3D">启用 3D</system:String>
+    <system:String x:Key="Disable3D">禁用 3D</system:String>
+    <system:String x:Key="EnableDriverMod">启用驱动修改</system:String>
+    <system:String x:Key="DisableDriverMod">禁用驱动修改</system:String>
+    <system:String x:Key="NoMatchFound">未找到匹配项：</system:String>
+
+    <!-- Tab header title -->
+    <system:String x:Key="Installation">安装</system:String>
+    <system:String x:Key="Play">启动</system:String>
+    <system:String x:Key="EditProfile">编辑配置</system:String>
+    <system:String x:Key="NewProfile">新建配置</system:String>
+    <system:String x:Key="Hotkeys">快捷键</system:String>
+    <system:String x:Key="3dfix">3D 修复</system:String>
+    <system:String x:Key="Profile">配置文件</system:String>
+    <system:String x:Key="Settings">设置</system:String>
+    <system:String x:Key="About">关于</system:String>
+    <system:String x:Key="GeneralSettings">应用程序设置</system:String>
+    <system:String x:Key="Nvidia3DSettings">Nvidia 3D 设置</system:String>
+    <system:String x:Key="DisplayProfiles">显示器配置</system:String>
+
+    <!-- Game list on left column-->
+    <system:String x:Key="AllGames">所有游戏</system:String>
+    <system:String x:Key="InstalledGames">已安装游戏</system:String>
+    <system:String x:Key="AllFixTypes">所有修复类型</system:String>
+    <system:String x:Key="_3dmigoto">3dmigoto (DX 11)</system:String>
+    <system:String x:Key="Helixmod">Helixmod (DX 9)</system:String>
+    <system:String x:Key="OpenGLwrapper">OpenGL 封装器</system:String>
+    <system:String x:Key="VulkanWrapper">Vulkan 封装器</system:String>
+    <system:String x:Key="NotFixed">无 3D 修复</system:String>
+    <system:String x:Key="VerifiedFixes">已验证的 3D 修复</system:String>
+    <system:String x:Key="UnverifiedFixes">未验证的 3D 修复</system:String>
+    <system:String x:Key="UE3">虚幻引擎 3 (UE3)</system:String>
+    <system:String x:Key="UE4">虚幻引擎 4 (UE4)</system:String>
+    <system:String x:Key="Unity">Unity</system:String>
+    <system:String x:Key="VrCompatible">兼容 VR</system:String>
+    <system:String x:Key="New">新建</system:String>
+    <system:String x:Key="CreateProfileToolTip">创建修复配置</system:String>
+    <system:String x:Key="Edit">编辑</system:String>
+    <system:String x:Key="EditProfileToolTip">编辑修复配置</system:String>
+    <system:String x:Key="Delete">删除</system:String>
+    <system:String x:Key="DeleteProfileToolTip">移除修复配置</system:String>
+    <system:String x:Key="FoundGames">列表游戏数：</system:String>
+
+    <!-- Installation Tab -->
+    <system:String x:Key="NoGamesInstalled">未安装兼容的游戏。</system:String>
+    <system:String x:Key="Play2D">启动 2D 模式</system:String>
+    <system:String x:Key="Play3D">启动 3D 模式</system:String>
+    <system:String x:Key="PlayVR">在 VR 中启动</system:String>
+    <system:String x:Key="InstallFix">安装 3D 修复</system:String>
+    <system:String x:Key="InstallFixCompleted">安装完成</system:String>
+    <system:String x:Key="BackupRecoveryFailed">备份恢复失败。</system:String>
+    <system:String x:Key="InstallFixFailed">安装失败。请检查安装路径</system:String>
+    <system:String x:Key="InstallFixFailed02" xml:space="preserve">错误：无法安装修复程序。&#x0d;&#x0d;请确保 3D Fix Manager 以管理员权限启动，然后重试。</system:String>
+    <system:String x:Key="InstallWrapperFailed" xml:space="preserve">错误：无法安装封装器 (Wrapper)。&#x0d;&#x0d;请确保 3D Fix Manager 以管理员权限启动，然后重试。</system:String>
+    <system:String x:Key="FixWrapperOutdated">此修复包含过期版本的 3dmigoto。</system:String>
+    <system:String x:Key="DownloadFix">下载 3D 修复</system:String>
+    <system:String x:Key="UninstallFix">卸载 3D 修复</system:String>
+    <system:String x:Key="UninstallFixCompleted">卸载完成</system:String>
+    <system:String x:Key="UninstallFixFailed">卸载失败</system:String>
+    <system:String x:Key="InstallWrapper">安装 3D 封装器</system:String>
+    <system:String x:Key="UninstallWrapper">卸载 3D 封装器</system:String>
+    <system:String x:Key="DeleteDownload">清除下载缓存</system:String>
+    <system:String x:Key="DeleteDownloadToolTip">从 3D Fix Manager 目录中删除已下载的 3D 修复文件。</system:String>
+    <system:String x:Key="DeleteSuccess">成功。所有下载的文件已删除。</system:String>
+    <system:String x:Key="DeleteError" xml:space="preserve">错误：未能删除所有文件。&#x0d;&#x0d;请确保没有文件正在被使用。</system:String>
+    <system:String x:Key="SourceFolder">配置文件夹</system:String>
+    <system:String x:Key="SourceFolderToolTip">打开 Windows 资源管理器并显示与此 3D 修复配置相关的所有文件。</system:String>
+    <system:String x:Key="VisitSteamStore">产品页面</system:String>
+    <system:String x:Key="VisitSteamStoreToolTip">打开浏览器以显示有关该游戏的更多信息。</system:String>
+    <system:String x:Key="VisitHelixMod">HelixMod 博客</system:String>
+    <system:String x:Key="VisitHelixModToolTip">在 HelixMod 网页上获取有关所选修复的更多信息。</system:String>
+    <system:String x:Key="ForceCompatibilityMode">启用 CMU</system:String>
+    <system:String x:Key="EnableFix">启用修复</system:String>
+    <system:String x:Key="DownloadCompleted">下载完成</system:String>
+    <system:String x:Key="Downloading">正在下载...</system:String>
+    <system:String x:Key="DownloadFailed">下载失败。</system:String>
+    <system:String x:Key="Extracting">正在提取...</system:String>
+    <system:String x:Key="ExtractionFailed">提取失败。</system:String>
+    <system:String x:Key="GameNotInstalled">游戏未安装</system:String>
+    <system:String x:Key="OpenExplorerError">错误：无法在 Windows 资源管理器中打开路径。路径不存在。</system:String>
+    <system:String x:Key="HotkeyBackupFound" xml:space="preserve">找到了快捷键和 3D 修复配置的备份。&#x0d;&#x0d;您想要恢复备份吗？</system:String>
+    <system:String x:Key="CreateHotkeyBackup">在卸载前，您是否想要备份您的快捷键和 3D 修复配置？</system:String>
+    <system:String x:Key="ThirdPartyDllError" xml:space="preserve">警告：在游戏目录中发现了一个与 3D 修复同名的第三方 DLL。&#x0d;&#x0d;DLL 路径: {0}&#x0d;&#x0d;在安装 3D 修复之前，您要备份此文件吗？</system:String>
+
+    <!--.................... New / Edit Profile Tab Begin .......................... -->
+
+    <system:String x:Key="VrCompatibility">兼容 VR：</system:String>
+    <system:String x:Key="VrWarnMultiplayerOnline">显示多人游戏警告：</system:String>
+    <system:String x:Key="Uses3DDirect">使用 3D 直连模式：</system:String>
+    <system:String x:Key="OptimizedConvergenceValue">优化的汇聚值：</system:String>
+    <system:String x:Key="MaxConvergenceValue">最大汇聚值：</system:String>
+    <system:String x:Key="MainSettingsGroup">标题及 3D 修复状态：</system:String>
+    <system:String x:Key="VrSettingsGroup">虚拟现实 (VR)：</system:String>
+    <system:String x:Key="HelixApiSettingsGroup">Helix / Google Blogger API：</system:String>
+    <system:String x:Key="PrimaryDownloadGroup">下载 3D 修复：</system:String>
+    <system:String x:Key="AlternativeDownloadGroup">下载替代版本的 3D 修复：</system:String>
+    <system:String x:Key="InstallFixSettingsGroup">安装 3D 修复：</system:String>
+    <system:String x:Key="GameConfigSettingsGroup">游戏配置：</system:String>
+    <system:String x:Key="OverrideMonitorProfileGroup">覆盖显示器配置：</system:String>
+    <system:String x:Key="OverrideTVProfileGroup">覆盖电视配置：</system:String>
+    <system:String x:Key="OverrideProjectorProfileGroup">覆盖投影仪配置：</system:String>
+    <system:String x:Key="GameIconSettingsGroup">游戏图标：</system:String>
+    <system:String x:Key="DriverSettingsGroup">Nvidia Profile Inspector 的驱动设置/配置文件：</system:String>
+    <system:String x:Key="GameLaunchSettingsGroup">游戏启动：</system:String>
+    <system:String x:Key="MiscSettingsGroup">杂项设置：</system:String>
+    <system:String x:Key="FixDescriptionSettingsGroup">3D 修复描述 / Helix 博客：</system:String>
+
+    <system:String x:Key="GameTitle">*游戏标题：</system:String>
+    <system:String x:Key="RelativeInstallPath">*相对安装路径：</system:String>
+    <system:String x:Key="InstallDir">安装文件夹：</system:String>
+    <system:String x:Key="InstallDirName">*安装文件夹名称：</system:String>
+    <system:String x:Key="CustomRootPath">自定义根目录 / 游戏路径：</system:String>
+    <system:String x:Key="RelativeGameIniPath">1. 游戏配置文件的相对路径：</system:String>
+    <system:String x:Key="SecondRelativeGameIniPath">2. 游戏配置文件的相对路径：</system:String>
+    <system:String x:Key="ThirdRelativeGameIniPath">3. 游戏配置文件的相对路径：</system:String>
+    <system:String x:Key="SetDate">设置日期</system:String>
+    <system:String x:Key="SetDateTooltip">将今天的日期设置为时间戳。</system:String>
+    <system:String x:Key="DownloadLink_1">1. 3D 修复下载地址：</system:String>
+    <system:String x:Key="DownloadLink_2">2. 3D 修复下载地址：</system:String>
+    <system:String x:Key="DownloadLink_3">3. 3D 修复下载地址：</system:String>
+    <system:String x:Key="InfoAlternativeUrl">关于替代 3D 修复的信息：</system:String>
+    <system:String x:Key="FixArchiveExtractor">修复包解压工具：</system:String>
+    <system:String x:Key="AllowFixInstallation">允许安装 3D 修复：</system:String>
+    <system:String x:Key="AllowMigotoUpdate">允许 3dmigoto 封装器更新：</system:String>
+    <system:String x:Key="StereoRefreshRateOverride">立体 3D 刷新率：</system:String>
+    <system:String x:Key="StartTool">启动额外的 Exe：</system:String>
+    <system:String x:Key="RequiresSwCursor">需要软件鼠标指针：</system:String>
+
+    <system:String x:Key="UniversalFixDetectionError">错误：无法通过搜索 PC Gaming Wiki 和 Wikipedia 检测到游戏引擎。</system:String>
+    <system:String x:Key="DetectEngine">检测引擎</system:String>
+    <system:String x:Key="WebLinkHelix">Helix 博客 / Geforce 论坛的 URL：</system:String>
+    <system:String x:Key="HelixPostUpdated">Helix 帖子最后更新于：</system:String>
+    <system:String x:Key="AllowHelixPostUpdate">允许自动更新帖子：</system:String>
+
+    <system:String x:Key="LocalIconPath">本地图标路径：</system:String>
+    <system:String x:Key="RemoteIconPath">远程图标路径：</system:String>
+    <system:String x:Key="DepthHackOverride">3D 深度 Hack：</system:String>
+    <system:String x:Key="DisableFixIn2DMode">在 2D 模式下禁用 3D 修复：</system:String>
+    <system:String x:Key="ProductPageUrl">产品页面 URL：</system:String>
+    <system:String x:Key="CmFlag">兼容性模式的十六进制值：</system:String>
+    <system:String x:Key="Profile2DMode">2D 模式的 Nvidia Inspector 配置文件：</system:String>
+    <system:String x:Key="Profile3DMode">3D 模式的 Nvidia Inspector 配置文件：</system:String>
+    <system:String x:Key="FixState">3D 修复状态：</system:String>
+    <system:String x:Key="SteamAppID">Steam App ID：</system:String>
+    <system:String x:Key="EpicAppID">Epic App ID：</system:String>
+
+    <system:String x:Key="WaitForExit">等待退出</system:String>
+    <system:String x:Key="GameExeAsArgument">使用 Game Exe 作为启动参数</system:String>
+    <system:String x:Key="Create">创建</system:String>
+    <system:String x:Key="GameLauncherExe">*游戏启动程序 Exe：</system:String>
+    <system:String x:Key="GameLauncherOptions">启动参数：</system:String>
+    <system:String x:Key="ModifyGameExe">修改游戏 Exe：</system:String>
+    <system:String x:Key="GameExeSearchString">搜索字符串：</system:String>
+    <system:String x:Key="GameExeReplaceString">替换字符串：</system:String>
+    <system:String x:Key="DoNotModify">不修改</system:String>
+    <system:String x:Key="ModifyNormalGameExe">修改游戏 Exe</system:String>
+    <system:String x:Key="ModifyAdditionalExe">修改额外的 Exe</system:String>
+    <system:String x:Key="FixDescription">修复描述：</system:String>
+
+    <system:String x:Key="CreateEditConfigFile">创建 / 编辑</system:String>
+    <system:String x:Key="EditOnlyConfigFile">仅编辑</system:String>
+
+    <!-- ComboBoxes -->
+    <system:String x:Key="SimpleView">精简视图</system:String>
+    <system:String x:Key="DetailedView">详细视图</system:String>
+
+    <system:String x:Key="NoProfileInstall">不安装配置文件</system:String>
+    <system:String x:Key="InstallWithDialog">带对话框提示安装</system:String>
+    <system:String x:Key="SilentInstallation">静默安装</system:String>
+
+    <system:String x:Key="Unknown">未知</system:String>
+    <system:String x:Key="FixBroken">修复已失效</system:String>
+    <system:String x:Key="FixBrokenToolTip">3D 修复目前已损坏或失效。</system:String>
+    <system:String x:Key="RequiresExtraSteps">需要用户执行额外步骤</system:String>
+    <system:String x:Key="RequiresExtraStepsToolTip">安装此修复需要用户执行额外的操作才能完成。请检查下方的描述。</system:String>
+    <system:String x:Key="WorksOutOfTheBox">开箱即用</system:String>
+    <system:String x:Key="WorksOutOfTheBoxToolTip">安装此修复不需要额外的步骤。这只是一个简单的一键安装。</system:String>
+
+    <system:String x:Key="CloseRTSS">关闭 RTSS</system:String>
+    <system:String x:Key="StartRTSS">启动 RTSS</system:String>
+
+    <system:String x:Key="StartByAppId">通过 Steam App ID 启动</system:String>
+    <system:String x:Key="StartByGameExe">通过游戏 Exe 启动</system:String>
+    <system:String x:Key="StartByToolExe">通过额外的 Exe 启动</system:String>
+
+    <system:String x:Key="RunNormal">正常运行</system:String>
+    <system:String x:Key="RunAsAdmin">以管理员身份运行</system:String>
+    <system:String x:Key="ApplyGlobalSetting">应用全局设置</system:String>
+    <system:String x:Key="OverrideGlobalSetting">覆盖全局设置</system:String>
+
+    <system:String x:Key="CustomText">自定义信息文本</system:String>
+    <system:String x:Key="SLI">SLI 信息文本</system:String>
+
+    <!-- Buttons-->
+    <system:String x:Key="ChoosePath">选择路径</system:String>
+    <system:String x:Key="PickFile">选取文件</system:String>
+    <system:String x:Key="RemoveIcon">移除图标</system:String>
+    <system:String x:Key="OpenUrl">打开 URL</system:String>
+    <system:String x:Key="SearchUrl">搜索 URL</system:String>
+    <system:String x:Key="SearchAppID">搜索 App ID</system:String>
+    <system:String x:Key="SearchInDB">在数据库中搜索</system:String>
+    <system:String x:Key="SearchSteamDb">搜索 Steam 数据库</system:String>
+    <system:String x:Key="ValuesFor2D">2D 模式参数</system:String>
+    <system:String x:Key="ValuesFor3D">3D 模式参数</system:String>
+    <system:String x:Key="Open">打开文件</system:String>
+    <system:String x:Key="OpenExplorer">打开资源管理器</system:String>
+    <system:String x:Key="Cancel">取消</system:String>
+    <system:String x:Key="Save">保存</system:String>
+    <system:String x:Key="SaveChanges">保存更改</system:String>
+    <system:String x:Key="CreateProfile">创建配置</system:String>
+    
+    <!--.................... Edit Profile Tab End .......................... -->
+
+    
+    <!--.................... Hotkeys Tab Begin .......................... -->
+
+    <!-- CMU Management Group-->
+    <system:String x:Key="CmuGameExe">游戏 Exe：</system:String>
+    <system:String x:Key="AutoPatch">启用自动打补丁：</system:String>
+    <system:String x:Key="PatchDelay">补丁延迟：</system:String>
+    <system:String x:Key="AutoUpdateDriver">更新驱动配置文件：</system:String>
+    <system:String x:Key="CmuSettings">兼容性模式解锁版 (CMU) 设置：</system:String>
+    <system:String x:Key="CmuWarning" xml:space="preserve">显示 CMU 警告</system:String>
+    <system:String x:Key="CmuWarningDialog" xml:space="preserve">警告：尽管 CMU 不是作弊工具，但在在线游戏中可能会被检测为作弊。这会导致您的游戏账号被封禁。
+
+因此，建议仅在单人或离线游戏中使用 CMU。</system:String>
+
+    <TextBlock x:Key="CmuWarningToolTip" TextWrapping="Wrap" Width="300">
+        警告用户在在线游戏中使用 CMU 可能会导致游戏账号被封禁。
+    </TextBlock>
+
+    <TextBlock x:Key="AutoUpdateDriverToolTip" TextWrapping="Wrap" Width="300">
+        此选项控制是否修改游戏的驱动配置文件。<LineBreak/><LineBreak/>
+        如果您已经安装了 3dmigoto，此选项会自动禁用，因为 3dmigoto 会负责设置兼容性模式的驱动配置。<LineBreak/><LineBreak/>
+        当未安装 3dmigoto 时，将使用 CMU 来调整驱动配置。
+    </TextBlock>
+
+    <TextBlock x:Key="AutoPatchToolTip" TextWrapping="Wrap" Width="300">
+        控制在启动游戏时是否自动启用 CMU。CMU 的激活会在一段时间后进行，您可以在下方的选项中调整此延迟。<LineBreak/><LineBreak/>
+        随后 CMU 会给 Nvidia 驱动打补丁，并允许通过按下 F11（默认键）使 CMU 快捷键生效，从而突破允许的最大 3D 深度限制。<LineBreak/><LineBreak/>       
+        如果保持此选项禁用，您必须在游戏中按 CTRL + SHIFT + T 手动启用 CMU。
+    </TextBlock>
+
+    <TextBlock x:Key="PatchDelayToolTip" TextWrapping="Wrap" Width="300">
+        定义游戏启动后自动启用 CMU 的延迟时间。
+    </TextBlock>
+
+    <TextBlock x:Key="CmuGameExeToolTip" TextWrapping="Wrap" Width="300">
+        用于启动游戏的可执行文件名称。<LineBreak/><LineBreak/>
+        这是自动设置的，除非必要，否则不应更改。
+    </TextBlock>
+
+    <TextBlock x:Key="CmuConvergenceToolTip" TextWrapping="Wrap" Width="300">
+       输入按下快捷键时您想要设置的汇聚值。<LineBreak/><LineBreak/>
+       有效值范围在 0.2 到 1.0 之间。高于或低于此范围的数字都会被 Nvidia 驱动截断。
+    </TextBlock>
+
+    <TextBlock x:Key="CmuSeparationToolTip" TextWrapping="Wrap" Width="300">
+        输入与当前 3D 深度相乘的系数。<LineBreak/><LineBreak/>
+        换句话说，您可以通过此系数突破兼容模式非常有限的 3D 深度，以增强 3D 效果。<LineBreak/><LineBreak/>
+        示例：如果您选择值为 2.2，这意味着您的最大 3D 深度增加了 220%。<LineBreak/><LineBreak/>
+        您也可以使用该系数来降低 3D 深度（例如，使用值 0.2）。<LineBreak/><LineBreak/>
+        这在第一人称射击游戏中特别有用，因为您需要按住鼠标右键瞄准，较低的 3D 深度会让瞄准时感觉更舒适。
+    </TextBlock>
+
+    <system:String x:Key="FixInfo">修复信息：</system:String>
+    <system:String x:Key="Game">游戏：</system:String>
+    <system:String x:Key="GameEngine">游戏引擎：</system:String>
+    <system:String x:Key="FixType">修复类型：</system:String>
+    <system:String x:Key="WrapperVersion">封装器版本：</system:String>
+    <system:String x:Key="IniPath">Ini 路径：</system:String>
+    <system:String x:Key="IniPath02">Ini 路径 2：</system:String>
+    <system:String x:Key="CreateIni">创建 Ini</system:String>
+    <system:String x:Key="ResetIniToDefault">将 Ini 重置为默认：</system:String>
+    <system:String x:Key="DownloadDefaultIni">下载默认 Ini</system:String>
+    <system:String x:Key="ManageHotkeys">管理快捷键：</system:String>
+    <system:String x:Key="NoIniProvided">此修复未提供 ini 文件</system:String>
+    <system:String x:Key="ParseError">抱歉，无法解析 ini 文件</system:String>
+    <system:String x:Key="HelixVersionNotDetected" xml:space="preserve">抱歉，无法确定 Helix 封装器版本。&#x0d;请点击“下载默认 Ini”以获取此信息</system:String>
+    <system:String x:Key="MigotoOld">3dmigoto (DirectX 11) - 旧版本</system:String>
+    <system:String x:Key="HelixModOld">Helix Mod (DirectX 9) - 旧版本</system:String>
+    <system:String x:Key="HotkeysNotSupportedMigoto">抱歉，此版本的 3dmigoto 不支持快捷键编辑。</system:String>
+    <system:String x:Key="HotkeysNotSupportedOpenGL">抱歉，此版本的 OpenGl 封装器不支持快捷键编辑。</system:String>
+
+    <!-- Hotkey Management Group -->
+    <system:String x:Key="HotkeyManagement">快捷键管理：</system:String>
+    <system:String x:Key="NewHotkey">新建快捷键</system:String>
+    <system:String x:Key="NewHotkeyToolTip">创建一个新快捷键。别忘了分配一个按键。</system:String>
+    <system:String x:Key="DeleteHotkey">移除按键</system:String>
+    <system:String x:Key="DeleteHotkeyToolTip">移除快捷键及所有对应的 3D 预设。</system:String>
+    <system:String x:Key="SelectedHotkey">选定的快捷键：</system:String>
+    <system:String x:Key="SelectedHotkeyToolTip">当前选中进行编辑的快捷键。</system:String>
+    <system:String x:Key="EditKeyBinding">编辑按键绑定：</system:String>
+    <system:String x:Key="KeyType">按键类型：</system:String>
+    <system:String x:Key="PressKeyToolTip">按下一个键来更改按键绑定。</system:String>
+    <system:String x:Key="ChooseInputDeviceToolTip">选择用于按键绑定的输入设备。</system:String>
+    <system:String x:Key="Description">描述：</system:String>
+    <system:String x:Key="DescriptionToolTip">关于该快捷键用途的简短说明。</system:String>
+    <system:String x:Key="ResetIniToolTip">将 ini 文件重置为原始状态。</system:String>
+    
+    <!-- Preset Management Group -->
+    <system:String x:Key="PresetManagement">预设管理：</system:String>
+    <system:String x:Key="NewPreset">新建预设</system:String>
+    <system:String x:Key="NewPresetToolTip">创建一个新的 3D 预设。</system:String>
+    <system:String x:Key="DefaultPreset">默认预设：</system:String>
+    <system:String x:Key="Delay">延迟：</system:String>
+    <system:String x:Key="ReleaseDelay">释放延迟：</system:String>
+    <system:String x:Key="Transition">过渡：</system:String>
+    <system:String x:Key="ReleaseTransition">释放过渡：</system:String>
+    
+    <!-- Preset Group -->   
+    <system:String x:Key="UseStereoSettings">使用立体 3D 设置</system:String>
+    <system:String x:Key="UseStereoSettingsToolTip">启用此项以允许该预设在游戏中更改分离度和/或汇聚设置。</system:String>
+    
+    <system:String x:Key="SaveStereoSettings">在游戏中使用 F7 保存立体 3D 设置：</system:String>
+    <system:String x:Key="SaveStereoSettingsToolTip">启用此项以允许在游玩时更改预设。确保您在游戏中通过按快捷键按钮选择预设，使用 CTRL + F3 - F6 更改 3D 深度/汇聚至您喜欢的程度，然后按 F7 保存。</system:String>
+
+    <system:String x:Key="chkStereoSeparationToolTip">启用此项以设置 3D 分离度。取消选中将从 ini 文件中删除相应条目。</system:String>
+    <system:String x:Key="sliderStereoSeparationToolTip">设置百分比格式的 3D 分离度。</system:String>
+    
+    <system:String x:Key="Convergence">汇聚：</system:String>
+    <system:String x:Key="chkConvergenceToolTip">启用此项以设置汇聚。取消选中将从 ini 文件中删除相应条目。</system:String>
+    <system:String x:Key="tbConvergenceToolTip">将汇聚设置为浮点数。</system:String>
+
+    <system:String x:Key="chkShaderConstToolTip">启用此项以定义一个 Shader 常量并设置其值。取消选中将从 ini 文件中删除相应条目。</system:String>
+    <system:String x:Key="chbShaderConstToolTip">选择要传递给 Shader 的常量。</system:String>
+    <system:String x:Key="tbShaderConstToolTip">将常量值设置为浮点数。</system:String>
+    <system:String x:Key="NewConstant">新建常量</system:String>
+    <system:String x:Key="NewConstantToolTip">创建一个新的 Shader 常量。</system:String>
+    <system:String x:Key="DefaultConstToolTip">输入一个浮点数。</system:String>
+
+    <system:String x:Key="RemovePresetToolTip">从 ini 文件中删除整个预设。</system:String>
+
+    <!-- General Ini Settings group -->
+    <system:String x:Key="GeneralIniSettings">常规 Ini 设置：</system:String>
+    <system:String x:Key="StereoOverlay">立体 3D 覆盖层：</system:String>
+    <system:String x:Key="EnableStereoOverlay">立体 3D 覆盖层 / 狩猎模式：</system:String>
+    <system:String x:Key="ShowHideOverlay">显示 / 隐藏立体 3D 覆盖层：</system:String>
+    <system:String x:Key="ShowHideOverlayToolTip">隐藏覆盖层的快捷键。注意：这不会禁用狩猎模式。</system:String>
+    <system:String x:Key="ReloadIniFile">在游戏中重新加载 Ini 文件：</system:String>
+    <system:String x:Key="ReloadIniFileToolTip">在游玩时重新加载 ini 并应用快捷键/预设的更改。</system:String>
+    <system:String x:Key="DefaultValuesConstants">Shader 常量的默认值：</system:String>
+    <system:String x:Key="EnableAlternative3dMode">启用替代的 3D 格式：</system:String>
+    <system:String x:Key="EnableAlternative3dModeToolTip">选择适用于 3D 电视和投影仪的替代 3D 格式。</system:String>
+    <system:String x:Key="EnableSoftwareMouse">启用软件鼠标指针</system:String>
+    <system:String x:Key="Constant">常量</system:String>
+    <system:String x:Key="ResolutionAndRefreshRates">分辨率和刷新率：</system:String>
+    <system:String x:Key="EnableUpscaling">启用画面缩放 (Upscaling)：</system:String>
+    <system:String x:Key="UpscalingMode">画面缩放模式：</system:String>
+    <system:String x:Key="OverrideScreenWidth">覆盖屏幕宽度：</system:String>
+    <system:String x:Key="OverrideScreenHeight">覆盖屏幕高度：</system:String>
+    <system:String x:Key="OverrideScreenToolTip">强制覆盖屏幕分辨率。</system:String>
+    <system:String x:Key="UpscalingScreenWidth">画面缩放目标宽度：</system:String>
+    <system:String x:Key="UpscalingScreenHeight">画面缩放目标高度：</system:String>
+    <system:String x:Key="OverrideRefrehRate">覆盖刷新率：</system:String>
+    <system:String x:Key="OverrideRefrehRateToolTip">覆盖由游戏设置的刷新率。</system:String>
+    <system:String x:Key="FilterRefreshRates">过滤刷新率</system:String>
+    <system:String x:Key="ForceFullscreen">在游戏启动时强制全屏：</system:String>
+    <system:String x:Key="ForceFullscreenOnKeyPress">按键时强制全屏：</system:String>
+    <system:String x:Key="ToggleFullscreen">切换全屏：</system:String>
+    <system:String x:Key="ForcedFullscreen">强制全屏</system:String>
+    <system:String x:Key="NormalFullscreen">普通全屏</system:String>
+    <system:String x:Key="SoftDisabled">软禁用</system:String>
+    <system:String x:Key="TypeInIntegerToolTip">输入一个整数值。</system:String>
+    <system:String x:Key="TypeInCommaSeparatedListToolTip">输入以逗号分隔的刷新率列表。</system:String>
+
+    <!-- Driver Profile Settings group -->
+    <system:String x:Key="DriverProfileSettings">驱动配置设置：</system:String>
+    <system:String x:Key="Stereo3DSettings">立体 3D 设置：</system:String>
+    <system:String x:Key="CompatibilityModeSettings">3D 兼容模式设置：</system:String>
+    <system:String x:Key="VisionReady">3D Vision Ready (官方适配)</system:String>
+    <system:String x:Key="VisionReadyToolTip">更改立体视觉质量的评级。</system:String>
+    <system:String x:Key="Excellent">极佳 (Excellent)</system:String>
+    <system:String x:Key="Good">良好 (Good)</system:String>
+    <system:String x:Key="Fair">一般 (Fair)</system:String>
+    <system:String x:Key="Not Recommended">不推荐 (Not Recommended)</system:String>
+    
+    <!--.................... Hotkeys Tab End .......................... -->
+
+
+    <!--.................... Drivers View Begin ....................-->
+
+    <system:String x:Key="Drivers">驱动程序</system:String>
+    <system:String x:Key="Stereo3dDriver">立体 3D 驱动：</system:String>
+    <system:String x:Key="3dDriver">3D 驱动：</system:String>
+    <system:String x:Key="DriverVersion">驱动版本：</system:String>
+    <system:String x:Key="DriverIntegrity">驱动完整性：</system:String>
+    <system:String x:Key="IrEmitterDriver">红外发射器驱动：</system:String>
+    <system:String x:Key="Stereo3d">立体 3D：</system:String>
+    <system:String x:Key="3dSetup">3D 设置：</system:String>
+    <system:String x:Key="Details">详情：</system:String>
+
+    <system:String x:Key="GraphicsDriver">显卡驱动：</system:String>
+    <system:String x:Key="GeforceDriver">GeForce 驱动：</system:String>
+    <system:String x:Key="GeforceDriverType">驱动类型：</system:String>
+
+    <system:String x:Key="VirtualReality">虚拟现实 (VR)：</system:String>
+    <system:String x:Key="SteamVR">SteamVR：</system:String>
+    <system:String x:Key="WmrCompatibility">WMR 崩溃修复：</system:String>
+    <system:String x:Key="Installed">已安装</system:String>
+    <system:String x:Key="NotInstalled">未安装</system:String>
+    <system:String x:Key="Enabled">已启用</system:String>
+    <system:String x:Key="Disabled">已禁用</system:String>
+    <system:String x:Key="InitFailed">初始化失败</system:String>
+    <system:String x:Key="VrHealthOk">VR 的所有组件均已安装，且 VR 头显已连接到电脑。</system:String>
+    <system:String x:Key="VrHealthOkDetails">SteamVR 已成功启动。您的系统已就绪，可体验 VR。</system:String>
+    <system:String x:Key="SteamVrNotInstalled">Steam VR 未安装。</system:String>
+    <system:String x:Key="SteamVrNotInstalledDetails">请安装 SteamVR 以在 VR 模式下进行游戏。</system:String>
+    <system:String x:Key="SteamVrInitializationFailed">Steam VR 初始化失败。</system:String>
+    <system:String x:Key="SteamVrInitializationFailedDetails">请检查您当前的 SteamVR 安装状态，并在必要时重新启动它。</system:String>
+    <system:String x:Key="VrHeadsetNotConnected">VR 头显未连接。</system:String>
+    <system:String x:Key="VrHeadsetNotConnectedDetails">请将您的 VR 头显连接到电脑，并重新启动 SteamVR。</system:String>
+    <system:String x:Key="WmrFixNotInstalled">Windows Mixed Reality (WMR) 崩溃修复尚未安装。</system:String>
+    <system:String x:Key="WmrFixNotInstalledDetails">请安装此崩溃修复，以便同时使用立体 3D 和 VR。</system:String>
+    <system:String x:Key="FramerateLimiterDisabled">VR 游戏的帧率限制器已禁用。</system:String>
+    <system:String x:Key="FramerateLimiterDisabledDetails">请在 VR 显示器配置中启用帧率限制，以避免游戏出现卡顿。</system:String>
+    <system:String x:Key="FramerateLimiterSetWrong">帧率限制超过了您 VR 头显支持的最大刷新率。</system:String>
+    <system:String x:Key="FramerateLimiterSetWrongDetails">请降低帧率限制，使其低于您 VR 头显支持的最大刷新率，以避免游戏中的卡顿现象。</system:String>
+    <system:String x:Key="InstallSteamVr">安装 SteamVR</system:String>
+    <system:String x:Key="InstallWmrCrashFix">安装 WMR 崩溃修复</system:String>
+    <system:String x:Key="EnableFramerateLimiter">启用帧率限制</system:String>
+    <system:String x:Key="SetFramerateLimiter">设置帧率限制</system:String>
+    <system:String x:Key="GameStartFailedVrMissing" xml:space="preserve">错误：未能在 VR 模式下启动游戏，因为一个或多个 VR 组件缺失或尚未设置。&#x0d;&#x0d;请检查 VR 状态并安装所需的任何组件。</system:String>
+    <system:String x:Key="Loading">加载中... 请稍候。</system:String>
+    <system:String x:Key="LaptopMonitor">笔记本显示器</system:String>
+
+    <system:String x:Key="DetectedHardware">检测到的硬件：</system:String>
+    <system:String x:Key="ComputerType">电脑类型：</system:String>
+    <system:String x:Key="GraphicsCard">显卡：</system:String>
+    <system:String x:Key="PrimaryDisplay">主显示器：</system:String>
+    <system:String x:Key="IrEmitter">红外发射器：</system:String>
+
+    <system:String x:Key="Connected">已连接</system:String>
+    <system:String x:Key="NotConnected">未连接</system:String>
+    <system:String x:Key="DllVersionInvalid">DLL 版本无效</system:String>
+    <system:String x:Key="DchStereoFileMissing">DCH 立体 3D 文件缺失</system:String>
+    <system:String x:Key="NoNvidiaCardInstalled">未安装 Nvidia 显卡</system:String>
+    <system:String x:Key="Completed">已完成</system:String>
+    <system:String x:Key="NotCompleted">未完成</system:String>
+
+    <system:String x:Key="IrEmitterDriverNotInstalled">未安装红外发射器驱动。</system:String>
+    <system:String x:Key="IrEmitterDriverNotInstalledDetails">请安装该驱动，以使您的 3D Vision 眼镜能在立体 3D 模式下工作。</system:String>
+    
+    <system:String x:Key="GraphicsCardNotSupported">您的显卡不支持立体 3D (Stereoscopic 3D)。</system:String>
+    <system:String x:Key="GraphicsCardNotSupportedDetails">要游玩立体 3D 游戏，必须使用 Nvidia 显卡。不支持 AMD 和 Intel 显卡。</system:String>
+
+    <system:String x:Key="GeforceDriverNotInstalled">未安装显卡驱动。</system:String>
+    <system:String x:Key="GeforceDriverNotInstalledDetails">请安装 Nvidia GeForce 显卡驱动，以便立即开始游玩立体 3D 游戏。</system:String>
+
+    <system:String x:Key="NativeLaptopMonitorUsed">笔记本自带的显示器不支持立体 3D。</system:String>
+    <system:String x:Key="NativeLaptopMonitorUsedDetails">请连接外部显示器，并将其设置为主显示器。</system:String>
+    
+    <system:String x:Key="StereoDriverNotInstalled">3D 驱动未安装。</system:String>
+    <system:String x:Key="StereoDriverNotInstalledDetails">请安装该驱动程序，以便立即在立体 3D 模式手游玩。</system:String>
+    
+    <system:String x:Key="StereoSetupNotCompleted">3D 设置尚未完成。</system:String>
+    <system:String x:Key="StereoSetupNotCompletedDetails">请立即完成设置，以便游玩立体 3D 游戏。</system:String>
+    
+    <system:String x:Key="StereoNotEnabled">未在驱动中启用 3D。</system:String>
+    <system:String x:Key="StereoNotEnabledDetails">请启用它以游玩立体 3D 游戏。</system:String>
+    
+    <system:String x:Key="StereoDriverCorrupt">3D 驱动已损坏。</system:String>
+    <system:String x:Key="StereoDriverCorruptDetails">请进行修复以游玩立体 3D 游戏。</system:String>
+    
+    <system:String x:Key="StereoDriverOk">所有立体 3D 驱动组件均已安装。</system:String>
+    <system:String x:Key="StereoDriverOkDetails">您的系统已就绪，可体验 3D。</system:String>
+    
+    <system:String x:Key="InstallStereoDriver">安装 3D 驱动</system:String>
+    <system:String x:Key="InstallIrEmitterDriver">安装红外发射器驱动</system:String>
+    <system:String x:Key="RepairStereoDriver">修复 3D 驱动</system:String>
+    <system:String x:Key="CompleteStereoSetup">完成 3D 设置</system:String>
+    <system:String x:Key="EnableStereo3D">启用 3D</system:String>
+
+    <system:String x:Key="ExtractingStereoDriver">正在提取 3D 驱动。请稍候...</system:String>
+    <system:String x:Key="InstallingStereoDriver">正在安装 3D 驱动。请稍候...</system:String>
+    <system:String x:Key="InstallingIrDriver">正在安装红外发射器驱动。请稍候...</system:String>
+    <system:String x:Key="CompletingStereoSetup">正在完成立体 3D 设置。请稍候...</system:String>
+    <system:String x:Key="LoadingStereoSettings">正在加载 3D 设置配置文件...</system:String>
+    <system:String x:Key="EnablingStereo3D">正在启用立体 3D。请稍候...</system:String>
+
+    <system:String x:Key="InstallFailed">驱动安装失败。</system:String>
+    <system:String x:Key="StereoActivationError">未能启用立体 3D。原因未知。</system:String>
+    <system:String x:Key="StereoActivationFailed" xml:space="preserve">错误：未能启用立体 3D，因为一个或多个 3D 驱动组件缺失或尚未设置。&#x0d;&#x0d;请检查驱动状态并安装所需的任何组件。</system:String>
+    <system:String x:Key="StereoActivationErrorLaptop">未能启用立体 3D。请将外部显示器连接到笔记本电脑并将其设置为主显示器。</system:String>
+    <system:String x:Key="StereoSetupFailed">立体 3D 设置失败。</system:String>
+    <system:String x:Key="DownloadingDrivers">正在下载驱动...</system:String>
+    <system:String x:Key="ExtractingDrivers">正在提取驱动。请稍候...</system:String>
+    <system:String x:Key="InstallingDrivers">正在安装驱动...</system:String>
+
+    <system:String x:Key="GeforceDriverNoDx11Support">安装的显卡驱动与立体 3D 模式下的 DirectX 11 游戏不兼容。</system:String>
+    <system:String x:Key="GeforceDriverNoDx11SupportDetails">请安装 GeForce 驱动 452.06 或更早版本，以恢复所有游戏的全面立体 3D 兼容性。</system:String>
+    <system:String x:Key="InstallGeforceDriverVersion">安装标准版 GeForce 驱动 {0}</system:String>
+    <system:String x:Key="InstallDchGeforceDriverVersion">安装 DCH 版 GeForce 驱动 {0}</system:String>
+    <system:String x:Key="OfficialNvidiaDownload">(从 Nvidia 官方服务器下载)</system:String>
+    <system:String x:Key="DriverUpdateAvailable">有新的 GeForce 驱动可用。</system:String>
+    <system:String x:Key="DriverUpdateAvailableDetails">驱动更新是可选的，且对于立体 3D 来说并非必须。</system:String>
+    <system:String x:Key="LatestDriverInstalled">最适合游玩立体 3D 游戏的 GeForce 驱动已安装。</system:String>
+    <system:String x:Key="LatestDriverInstalledDetails">每当有新的 GeForce 驱动发布时，都会在此通知您。</system:String>
+
+    <system:String x:Key="DchDriverInstalled">已安装 DCH 版本的 Geforce 驱动。</system:String>
+    <system:String x:Key="DchDriverInstalledDetails">请安装“标准 (Standard)”版本的 GeForce 驱动，以获得更好的立体 3D 体验。</system:String>
+    <system:String x:Key="ShowMoreInformation">显示更多信息</system:String>
+    <system:String x:Key="CancelDownload">取消下载</system:String>
+    <system:String x:Key="Remaining">剩余：</system:String>
+    <system:String x:Key="DownloadUrlInvalid">下载失败。无网络连接或服务器不可用。</system:String>
+    <system:String x:Key="ExtractingGeforceDriver">正在提取 GeForce 驱动。请稍候...</system:String>
+    <system:String x:Key="InstallingGeforceDriver">正在安装 GeForce 驱动。请稍候...</system:String>
+
+    <!--.................... Drivers View End -->
+
+
+    <!--.................... Application Settings Tab Begin .......................... -->
+
+    <!-- General Settings group -->
+    <system:String x:Key="GeneralSettingsGroup">常规设置：</system:String>
+    <system:String x:Key="UseProgramFor">程序用途：</system:String>
+    <system:String x:Key="CheckForUpdates">启动时检查程序更新</system:String>
+    <system:String x:Key="CheckForDriverUpdates">启动时检查驱动程序更新</system:String>
+    <system:String x:Key="UseHwAcceleration">启用 GUI 硬件加速</system:String>
+    <system:String x:Key="AllowChangesToGameConfig">为立体 3D 优化游戏设置</system:String>
+    <system:String x:Key="EnableSteamOverlay">启用 Steam 覆盖层 (Overlay)</system:String>
+    <system:String x:Key="FullscreenOptimizations">全屏优化：</system:String>
+    <system:String x:Key="ControlledByFixProfile">由修复配置控制</system:String>
+    <system:String x:Key="SteamNotDetected">未检测到覆盖层 DLL / Steam</system:String>
+    <system:String x:Key="PreferIconDownload">首选从互联网数据库下载游戏图标</system:String>
+    <system:String x:Key="ResetAllIcons">重置所有游戏图标：</system:String>
+    <system:String x:Key="DoNotChangeSetting">保留当前设置</system:String>
+    <system:String x:Key="DownloadScreenshots">下载立体 3D 截图</system:String>
+
+    <!-- 3D Fix / 3dmigoto settings group -->
+    <system:String x:Key="FixAnd3dmigotoSettings">3D 修复 / 3dmigoto 设置：</system:String>
+    <system:String x:Key="ReinstallFixFromCache">如果可能，从下载缓存中安装 3D 修复</system:String>
+    <system:String x:Key="ClearAllDownloadCache">清除所有修复配置的下载缓存：</system:String>
+    <system:String x:Key="EnableAllFixes">启用 / 禁用所有修复：</system:String>
+    <system:String x:Key="DisableFixesIn2dMode">在 2D 模式下禁用 3D 修复：</system:String>
+    <system:String x:Key="EnableAllFixesToolTip">启用所有已安装的 3D 修复。</system:String>
+    <system:String x:Key="DisableAllFixesToolTip">禁用所有已安装的 3D 修复。</system:String>
+    <system:String x:Key="SendData">当用户自定义修复配置时发送数据</system:String>
+    <system:String x:Key="AutoUpdate3dmigoto">启动时更新 3dmigoto</system:String>
+    <system:String x:Key="UpdateAllWrappers">为所有已安装的 3D 修复更新 3dmigoto：</system:String>
+    
+    <!-- Search paths group -->
+    <system:String x:Key="SearchPathsGroup">检测已安装的游戏：</system:String>
+    <system:String x:Key="EnableCachedPaths">缓存检测到的游戏以加快应用启动速度</system:String>
+    <system:String x:Key="EnableRegistrySearch">在 Windows 注册表中搜索游戏</system:String>
+    <system:String x:Key="EnableSearchPaths">在指定目录中搜索游戏（搜索路径）</system:String>
+    <system:String x:Key="PrioritizeSearchPaths">优先使用搜索路径而非 Windows 注册表中的路径</system:String>
+    <system:String x:Key="SearchDepth">搜索深度：</system:String>
+    <system:String x:Key="SearchPaths">搜索路径：</system:String>
+    <system:String x:Key="SearchGames">搜索游戏</system:String>
+    <system:String x:Key="DetectPaths">检测游戏库</system:String>
+    <system:String x:Key="DetectPathsToolTip">自动检测 Steam、Uplay、Origin、暴雪战网和 GOG Galaxy 的游戏库，并将它们添加为搜索路径。</system:String>
+    <system:String x:Key="Add">添加</system:String>
+    <system:String x:Key="AddPathToolTip">添加搜索路径。</system:String>
+    <system:String x:Key="Remove">移除</system:String>
+    <system:String x:Key="RemovePathToolTip">移除选定的搜索路径。</system:String>
+    <system:String x:Key="ChangePathToolTip">更改选定的搜索路径。</system:String>
+
+    <!-- RTSS settings group -->
+    <system:String x:Key="RtssSettingsGroup">RivaTuner Statistics Server (RTSS) 设置：</system:String>
+    <system:String x:Key="StartRTSS_Setting">根据修复配置来启动 / 关闭 RTSS</system:String>
+    <system:String x:Key="InterruptGameLaunch">暂停游戏启动以便设置 RTSS</system:String>
+    <system:String x:Key="CloseRivaTunerIn2D">在 2D 模式下启动游戏时关闭 RTSS</system:String>
+    <system:String x:Key="CloseRtssOnAppClose">退出 3D Fix Manager 时关闭 RTSS</system:String>
+    <system:String x:Key="RivaTunerNotDetected">未检测到或未安装 RivaTuner Statistics Server (RTSS)</system:String>
+    <system:String x:Key="RtssScanlineSyncNotSupportedError">RivaTuner Statistics Server 版本旧于 7.2</system:String>
+
+    <!-- Game Launcher Settings group -->
+    <system:String x:Key="GameLauncherSettings">游戏启动器设置：</system:String>
+    <system:String x:Key="StartGamesByGameExe">首选通过游戏启动器 Exe 启动游戏</system:String>
+    <system:String x:Key="StartGamesBySteamAppId">首选通过 Steam 客户端启动游戏（Steam App ID）</system:String>
+    <system:String x:Key="StartGamesByFixProfile">启动方法由修复配置控制（推荐）</system:String>
+
+    <!--Nvidia Profile Inspector Settings group -->
+    <system:String x:Key="NvidiaProfileInspectorSettings">Nvidia Profile Inspector 设置：</system:String>
+    <system:String x:Key="NeverInstallProfiles">全局禁用驱动配置文件的安装</system:String>
+    <system:String x:Key="ProfileInstallByFixProfile">驱动配置文件的安装由修复配置控制</system:String>
+    <system:String x:Key="InstallProfilesSilently">静默安装驱动配置文件（无警告消息）</system:String>
+    <system:String x:Key="NoNvidiaDetected">未检测到 / 未安装 Nvidia 驱动</system:String>
+    <system:String x:Key="Start">启动</system:String>
+    <system:String x:Key="StartProfileInspectorToolTip">启动 Nvidia Profile Inspector。</system:String>
+    <system:String x:Key="StartRtssToolTip">启动 RivaTuner Statistics Server。</system:String>
+
+    <!-- Stereo Refresh Rate Settings group -->
+    <system:String x:Key="StereoRefreshRateSettings">Nvidia 3D 眼镜快门频率 / 立体 3D 刷新率：</system:String>
+    <system:String x:Key="GlobalStereoRefreshRate">使用 Nvidia 驱动中设置的刷新率</system:String>
+    <system:String x:Key="ProfileStereoRefreshRate">刷新率由修复配置控制</system:String>
+
+    <!-- Buttons-->
+    <system:String x:Key="Disable">禁用</system:String>
+    <system:String x:Key="Enable">启用</system:String>
+    <system:String x:Key="Update">更新</system:String>
+    <system:String x:Key="Clear">清除</system:String>
+
+    <!--.................... General Settings Tab End .......................... -->
+
+   
+    <!--.................... Nvidia 3D Settings Tab Begin .......................... -->
+
+    <system:String x:Key="NvidiaNotDetected">未检测到 Nvidia 立体 3D</system:String>
+    <system:String x:Key="PressKeyCombination">在键盘上按下一个组合键。</system:String>
+    
+    <!-- General settings group -->
+    <system:String x:Key="EnableStereoGroup">启用 / 设置 3D 功能：</system:String>
+    <system:String x:Key="EnableNvidia3D">启用 Nvidia 立体 3D</system:String>
+    <system:String x:Key="Disable3dOnClosing">关闭应用程序时自动禁用 Nvidia 立体 3D</system:String>
+    <system:String x:Key="Disable3dOnGameClosing">关闭游戏时自动禁用 Nvidia 立体 3D</system:String>
+    <system:String x:Key="SetStereoTypeTo3DVision">强制使用 3D Vision / 3DTV Play 模式</system:String>
+    <system:String x:Key="StereoEnabledOnGameLaunch">游戏启动时已启用 3D 模式</system:String>
+    <system:String x:Key="StereoWindowedModeEnabled">在窗口模式下启用 3D (仅限 DirectX 9)</system:String>
+    <system:String x:Key="StereoModeAlwaysEnabled">3D 模式始终处于开启状态</system:String>
+    <system:String x:Key="StereoModeAlwaysEnabledToolTip">设置显示器是否永久处于 3D 模式（必须同时启用 3D 窗口模式）。</system:String>
+    <system:String x:Key="Nvida3dDriverOverlay">启用 Nvidia 3D 驱动覆盖层</system:String>
+    <system:String x:Key="LoadGeforceDllHackWith3dmigoto">通过 3dmigoto 应用 Geforce 驱动修改</system:String>
+    <system:String x:Key="UseGlobalDrickerHack">显示全局驱动 Hack 切换开关</system:String>
+    <system:String x:Key="EnableGeforceDllHack">启用 Geforce 驱动修改 (仅限 Windows 10)</system:String>
+    <system:String x:Key="ShowDriverHackDialog">在修改 Geforce 驱动前显示警告对话框</system:String>
+    <system:String x:Key="EnableWmrFix">启用 Windows Mixed Reality (WMR) 崩溃修复</system:String>
+    <system:String x:Key="InstallRecommendedGeforceDriver">安装推荐的 Geforce 驱动：</system:String>
+
+    <!-- 3D depth / 3D Vision shutter glasses group -->
+    <system:String x:Key="Advanced3dSettingsGroup">3D 深度 / 3D Vision 快门眼镜：</system:String>
+    <system:String x:Key="StereoSeparation">3D 深度 (分离度)：</system:String>
+    <system:String x:Key="DepthMultiplier">3D 深度倍增器：</system:String>
+    <system:String x:Key="Inch">英寸</system:String>
+    <system:String x:Key="StereoRefreshRate">3D 眼镜快门频率：</system:String>
+    <system:String x:Key="IROutput">红外发射器同步模式：</system:String>
+    <system:String x:Key="SingleIREnvironment">单红外环境</system:String>
+    <system:String x:Key="MixedIREnvironment">多红外环境</system:String>
+    <system:String x:Key="LanEnvironment">3D Vision 局域网环境</system:String>
+
+    <!-- Driver settings group -->
+    <system:String x:Key="DriverSettings2D">为 2D 模式优化全局驱动配置：</system:String>
+    <system:String x:Key="DriverSettings3D">为 3D 模式优化全局驱动配置：</system:String>
+    <system:String x:Key="MaxPreRenderedFrames">最大预渲染帧数：</system:String>
+    <system:String x:Key="VerticalSync">垂直同步：</system:String>
+    <system:String x:Key="MonitorTechnology">显示器技术：</system:String>
+    <system:String x:Key="GsyncMode">G-Sync 模式：</system:String>
+    <system:String x:Key="PreferredRefreshRate">首选刷新率：</system:String>
+    <system:String x:Key="PowerManagementMode">电源管理模式：</system:String>
+    <system:String x:Key="ApplicationControlled">由应用程序控制</system:String>
+    <system:String x:Key="Off">关</system:String>
+    <system:String x:Key="On">开</system:String>
+    <system:String x:Key="Fast">快 (Fast)</system:String>
+    <system:String x:Key="FixedRefreshRate">固定刷新率</system:String>
+    <system:String x:Key="G-SYNC">G-SYNC</system:String>
+    <system:String x:Key="ULMB">ULMB</system:String>
+    <system:String x:Key="FullscreenOnly">仅全屏</system:String>
+    <system:String x:Key="FullscreenAndWindowed">全屏和窗口</system:String>
+    <system:String x:Key="HighestAvailable">最高可用</system:String>
+    <system:String x:Key="MaximumPerformance">最高性能</system:String>
+    <system:String x:Key="OptimalPerformance">最佳性能 (Optimal)</system:String>
+    <system:String x:Key="Adaptive">自适应 (Adaptive)</system:String>
+    <system:String x:Key="AdaptiveHalf">自适应（半刷新率）</system:String>
+    <system:String x:Key="GlobalDriverProfileFile">导出的配置文件：</system:String>
+
+    <!-- General hotkeys group -->
+    <system:String x:Key="GeneralHotkeys">通用快捷键：</system:String>
+    <system:String x:Key="StereoToggle">显示 / 隐藏立体 3D 效果：</system:String>
+    <system:String x:Key="StereoToggleToolTip">在游戏时切换普通的 2D 画面与立体 3D 画面。</system:String>
+    <system:String x:Key="StereoSeparationAdjustLess">减小 3D 深度：</system:String>
+    <system:String x:Key="StereoSeparationAdjustLessToolTip">减小 3D 深度 / 分离度。</system:String>
+    <system:String x:Key="StereoSeparationAdjustMore">增加 3D 深度：</system:String>
+    <system:String x:Key="StereoSeparationAdjustMoreToolTip">增加 3D 深度 / 分离度。</system:String>
+    <system:String x:Key="ToggleMemo">显示 / 隐藏游戏内兼容性信息：</system:String>
+    <system:String x:Key="ToggleMemoToolTip">显示 / 隐藏包含兼容性信息和推荐游戏内设置的绿色文本。</system:String>
+
+    <!-- Advanced hotkeys group -->
+    <system:String x:Key="AdvancedHotkeys">高级快捷键：</system:String>
+    <system:String x:Key="StereoAdvancedHKConfig">启用高级游戏内快捷键</system:String>
+    <system:String x:Key="StereoAdvancedHKConfigToolTip">启用高级快捷键，以便更改汇聚 / 视锥体 (frustum) 设置及其他内容。</system:String>
+    <system:String x:Key="StereoConvergenceAdjustLess">减小汇聚：</system:String>
+    <system:String x:Key="StereoConvergenceAdjustLessToolTip">减弱游戏中的立体弹出感（出屏效果）。</system:String>
+    <system:String x:Key="StereoConvergenceAdjustMore">增加汇聚：</system:String>
+    <system:String x:Key="StereoConvergenceAdjustMoreToolTip">增强游戏中的立体弹出感（出屏效果）。</system:String>
+    <system:String x:Key="WriteConfig">保存游戏内更改：</system:String>
+    <system:String x:Key="WriteConfigToolTip">将汇聚和视锥体的调整保存至 Nvidia 驱动配置。</system:String>
+    <system:String x:Key="CycleFrustumAdjust">循环视锥体调整：</system:String>
+    <system:String x:Key="CycleFrustumAdjustToolTip">循环切换三种不同的视锥体调整。</system:String>
+    <system:String x:Key="StereoToggleMode">切换 3D 兼容模式：</system:String>
+    <system:String x:Key="StereoToggleModeToolTip">在 DirectX 11 游戏的兼容模式（伪 3D）和真实 3D 模式之间切换。</system:String>
+    
+    <!-- Screenshots group -->
+    <system:String x:Key="ScreenshotsGroup">截图：</system:String>
+    <system:String x:Key="StereoImageType">立体图像类型：</system:String>
+    <system:String x:Key="StereoImageTypeToolTip">设置立体图像的格式（JPS 或 PNS）。</system:String>
+    <system:String x:Key="StereoImageFolder">打开文件夹</system:String>
+    <system:String x:Key="StereoImageFolderToolTip">在 Windows 资源管理器中打开截图文件夹的位置。</system:String>
+    <system:String x:Key="SnapShotQuality">JPS 质量：</system:String>
+    <system:String x:Key="SnapShotQualityToolTip">决定图像质量和文件大小。</system:String>
+    <system:String x:Key="SaveStereoImage">截取屏幕截图：</system:String>
+    <system:String x:Key="SaveStereoImageToolTip">将立体截图保存到硬盘。</system:String>
+
+    <!-- LaserSight group -->
+    <system:String x:Key="LaserSightGroup">激光瞄准器：</system:String>
+    <system:String x:Key="LaserSightEnabled">启用激光瞄准器：</system:String>
+    <system:String x:Key="LaserSightEnabledToolTip">设置是否可以通过快捷键或 Nvidia 驱动配置自动启用 3D 激光瞄准器。</system:String>
+    <system:String x:Key="ToggleLaserSight">切换激光瞄准器：</system:String>
+    <system:String x:Key="ToggleLaserSightToolTip">在游戏中启用或禁用立体激光瞄准器。</system:String>
+    <system:String x:Key="LaserSightTransparency">激光瞄准器透明度：</system:String>
+    <system:String x:Key="LaserSightTransparencyToolTip">控制激光瞄准器的透明度。</system:String>
+    <system:String x:Key="LaserSightCrosshair">激光瞄准器样式：</system:String>
+    <system:String x:Key="LaserSightCrosshairToolTip">设置激光瞄准器的外观。</system:String>
+
+    <!-- Buttons-->
+    <system:String x:Key="Load">加载</system:String>
+    <system:String x:Key="Reset">重置</system:String>
+    <system:String x:Key="Apply">应用</system:String>
+
+    <!--.................... Nvidia 3D Settings Tab End .......................... -->
+
+    
+    <!--.................... Display Profiles Tab Begin .......................... -->
+
+    <system:String x:Key="MonitorProfileGroup">显示器配置：</system:String>
+    <system:String x:Key="TVProfileGroup">电视配置：</system:String>
+    <system:String x:Key="ProjectorProfileGroup">投影仪配置：</system:String>
+    <system:String x:Key="VrProfileGroup">VR 配置：</system:String>
+    <system:String x:Key="ProfileSettingsGroup">通用配置设置：</system:String>
+    <system:String x:Key="LinkProfileToDisplay">将配置文件关联到显示器：</system:String>
+    <system:String x:Key="DisplaySize">显示器尺寸：</system:String>
+    <system:String x:Key="RealScreenSize">屏幕尺寸：</system:String>
+    <system:String x:Key="DisplayType">3D 显示类型：</system:String>
+    <system:String x:Key="Preferred3dFormat">3dmigoto 3D 格式：</system:String>
+    <system:String x:Key="GameSettings2D">2D 模式的游戏设置：</system:String>
+    <system:String x:Key="GameSettings3D">3D 模式的游戏设置：</system:String>
+    <system:String x:Key="GameSettingsVR">VR 模式的游戏设置：</system:String>
+    <system:String x:Key="FramerateLimit">帧率限制：</system:String>
+    <system:String x:Key="DesktopSettings">桌面设置：</system:String>
+    <system:String x:Key="GameResolution">游戏分辨率：</system:String>
+    <system:String x:Key="GameResolution2D">2D 模式游戏分辨率：</system:String>
+    <system:String x:Key="GameResolution3D">3D 模式游戏分辨率：</system:String>
+    <system:String x:Key="DesktopResolution2D">2D 模式桌面分辨率：</system:String>
+    <system:String x:Key="DesktopResolution2DClosing">关闭时的桌面分辨率：</system:String>
+    <system:String x:Key="DesktopResolution3D">3D 模式桌面分辨率：</system:String>
+    <system:String x:Key="DesktopResolutionVr">桌面分辨率：</system:String>
+    <system:String x:Key="ShowProfileSelectionOnStartup">在应用程序启动时显示配置选择对话框</system:String>
+    <system:String x:Key="ShowProfileSelectionOnGameStart">在游戏启动时显示配置选择对话框</system:String>
+    <system:String x:Key="AllowDisplayProfileOverride">允许修复配置覆盖全局显示器配置</system:String>
+    <system:String x:Key="DefaultProfileOnStartup">启动时的默认配置：</system:String>
+    <system:String x:Key="PleaseChooseProfile">请选择一个显示器配置：</system:String>
+    <system:String x:Key="DoNotShowProfileSelection">不再显示此对话框</system:String>
+    <system:String x:Key="ShowProfileDialogOnGameStart">每次启动游戏时显示此对话框</system:String>
+    <system:String x:Key="ShowProfileDialogOnAppStart">每次启动应用程序时显示此对话框</system:String>
+
+    <!--.................... Display Profiles Tab End .......................... -->
+
+    
+    <!--.................... About Tab Begin .......................... -->
+
+    <system:String x:Key="ProgramDevelopedBy">程序开发者：</system:String>
+    <system:String x:Key="FixesDevelopedBy">3D 修复开发者：</system:String>
+    <system:String x:Key="DonationDeveloperToolTip">向 3D Fix Manager 的开发者发送捐款。</system:String>
+    <system:String x:Key="DonationShaderHackersToolTip">向 3D 修复程序的开发者（Shader 修改大神）发送捐款。</system:String>
+    <system:String x:Key="ProgramVersion">程序版本：</system:String>
+    <system:String x:Key="FixProfiles">配置版本：</system:String>
+    <system:String x:Key="CheckUpdate">检查更新</system:String>
+    <system:String x:Key="UpdateSuccess">更新已完成</system:String>
+    <system:String x:Key="UpdateFailed">更新失败</system:String>
+    <system:String x:Key="ChangeNotes">(更新日志)</system:String>
+    <system:String x:Key="Donate">捐赠</system:String>
+    <system:String x:Key="Installing">正在安装...</system:String>
+
+    <!-- Buttons -->
+    <system:String x:Key="Manual">用户手册</system:String>
+    <system:String x:Key="ReportBugs">报告 Bug</system:String>
+    <system:String x:Key="UpdateSteamDb">更新 Steam 数据库</system:String>
+    <system:String x:Key="CreateReleases">创建发布版 (Releases)</system:String>
+    <system:String x:Key="ReferenceDb">填充参考数据库</system:String>
+    <system:String x:Key="GithubLanguages">GitHub 语言设置</system:String>
+
+    <!--.................... About Tab End .......................... -->
+
+
+    <!--.................... Dialog Window Begin .......................... -->
+
+    <!-- Buttons-->
+    <system:String x:Key="Yes">是</system:String>
+    <system:String x:Key="No">否</system:String>
+    <system:String x:Key="Downgrade3dMigotoDialog" xml:space="preserve">您是否想将 3dmigoto 恢复为随此 3D 修复一起提供的原始版本？&#x0d;&#x0d;原始版本：{0}&#x0d;已安装版本：{1}</system:String>
+    <system:String x:Key="Install3dmigotox32">安装 3dmigoto x32</system:String>
+    <system:String x:Key="Install3dmigotox64">安装 3dmigoto x64</system:String>
+    <system:String x:Key="InstallOpenGLwrapperx32">安装 OpenGL x32</system:String>
+    <system:String x:Key="InstallOpenGLwrapperx64">安装 OpenGL x64</system:String>
+    <system:String x:Key="InstallHelixModx32">安装 HelixMod x32</system:String>
+    <system:String x:Key="InstallHelixModx64">安装 HelixMod x64</system:String>
+    <system:String x:Key="QuickSetup">快速设置</system:String>
+    <system:String x:Key="SetupWizard">设置向导</system:String>
+    <system:String x:Key="NormalFix">常规 3D 修复</system:String>
+    <system:String x:Key="SliFix">SLI 3D 修复</system:String>
+    <system:String x:Key="AlternativeFix">替代的 3D 修复</system:String>
+    <system:String x:Key="DriverType">驱动类型</system:String>
+
+    <!-- Messages -->
+    <system:String x:Key="GameStartFailedStereoMissing" xml:space="preserve">错误：未能在立体 3D 模式下启动游戏，因为一个或多个 3D 驱动组件缺失或未设置。&#x0d;&#x0d;请检查驱动状态并安装所需的任何组件。</system:String>
+    <system:String x:Key="GeforceDriverIncompatible" xml:space="preserve">错误：未能在立体 3D 模式下启动游戏，因为您当前安装的显卡驱动与 DirectX 11 游戏的立体 3D 不兼容。&#x0d;&#x0d;信息：Geforce 驱动版本 456.38 及更高版本受此问题影响。我们正在努力解决此问题，并对给您带来的不便深表歉意。</system:String>
+
+    <system:String x:Key="WizardCrashWarning" xml:space="preserve">警告：以下程序正在运行：&#x0d;&#x0d;{0}&#x0d;&#x0d;已知这些程序会导致 3D Vision 设置向导崩溃。&#x0d;&#x0d;请关闭上述程序，然后点击“确定”继续。</system:String>
+    <system:String x:Key="FailedToFindGeforceDriver">错误：在 Windows 驱动程序存储中找不到 Geforce 驱动。</system:String>
+
+    <!-- DCH Warning dialog -->
+    <system:String x:Key="DchWarningHeadline">警告：您当前安装的 Geforce 显卡驱动类型为“DCH”，我们不推荐在立体 3D 模式下使用它。</system:String>
+
+    <system:String x:Key="DchWarningDchExplanationTitle">“DCH”是什么意思？</system:String>
+    <system:String x:Key="DchWarningDchExplanation">DCH 是 Windows 10 引入的一种新驱动打包格式。微软的长期计划是将其作为 Windows 10 的默认驱动类型，并用 DCH 取代已安装的标准驱动。DCH 和标准驱动在本质上是相同的驱动程序，区别仅在于它们的打包和安装方式。</system:String>
+
+    <system:String x:Key="DchWarningDchWhyUnrecommendedTitle">为什么不推荐在立体 3D 中使用 DCH 驱动？</system:String>
+    <system:String x:Key="DchWarningDchWhyUnrecommended">对于当前的 DCH 驱动，恢复立体 3D 兼容性需要应用特殊变通方法，这会导致在 3D 模式下应用程序和游戏的加载时间显著增加。因此，目前我们不建议使用当前的 DCH 驱动，而是优先推荐使用标准驱动。</system:String>
+
+    <system:String x:Key="DchWarningDchWhereToGetDefaultTitle">在哪里可以获取“标准”版本的 Geforce 驱动？</system:String>
+    <system:String x:Key="DchWarningDchWhereToGetDefault">Nvidia 已开始在其下载页面隐藏标准驱动，以支持微软在 Windows 10 上分发 DCH 驱动的计划。然而，最新的标准驱动仍然可以在“Beta 驱动和存档”部分找到。如需手动安装标准驱动，只需点击下方的链接，并确保在网页上的“Windows 驱动程序类型”选项中选择“标准 (Standard)”。</system:String>
+
+    <system:String x:Key="DchWarningDchHowToReplaceTitle">如何用标准驱动替换 DCH 驱动？</system:String>
+    <system:String x:Key="DchWarningDchHowToReplace">从 Nvidia 驱动版本 441.12 开始，允许直接在“DCH”版本之上安装“标准”驱动以切换驱动类型。</system:String>
+
+    <system:String x:Key="DchWarningDchEasierWayTitle">是否有更简单的方法来切换到默认驱动？</system:String>
+    <system:String x:Key="DchWarningDchEasierWay">遗憾的是没有。如果替换 DCH 驱动的说明对您不起作用，您仍然可以选择安装 2019 年 5 月的旧版本 DCH 驱动 425.31，它在立体 3D 模式下依然能完美运行。您只需点击“安装 Geforce Driver 425.31 (DCH)”按钮即可自动完成。请注意，RTX 2070 Super / RTX 2080 Super 显卡不支持此驱动。</system:String>
+
+    <system:String x:Key="DownloadDDU">下载 DDU (显示驱动卸载程序)</system:String>
+    <system:String x:Key="DownloadStandardDriver">手动下载标准驱动</system:String>
+    <system:String x:Key="InstallDch42531">安装 Geforce 驱动 425.31 (DCH)</system:String>
+    <system:String x:Key="Install3DVisionDriver">安装 NVidia 3D Vision 驱动</system:String>
+
+    <!-- Recommended Driver dialog -->
+    <system:String x:Key="DriverUpdateRecommendedVersion" xml:space="preserve">Geforce 显卡驱动 425.31 是最后一个官方支持 3D Vision 的驱动。使用此驱动将带给您最佳体验，因为您无需处理各种驱动修改和黑客技巧来在当前驱动上恢复立体 3D。&#x0d;&#x0d;您是否想要立即安装 Geforce 驱动 425.31？</system:String>
+    <system:String x:Key="DriverAlreadyInstalled" xml:space="preserve">您的系统上已经安装了推荐的立体 3D 驱动 (Geforce 显卡驱动 425.31)。&#x0d;&#x0d;您是否想要立即重新安装该驱动？</system:String>
+
+    <!-- Driver update dialog -->
+    <system:String x:Key="DriverUpdateHeadline">有新的 Geforce 显卡驱动可用。您要更新您的驱动吗？</system:String>
+    <system:String x:Key="DriverUpdateInstalledDriver">已安装的驱动：</system:String>
+    <system:String x:Key="DriverUpdateInstalledDriverValue">占位符</system:String>
+    <system:String x:Key="DriverUpdateLatestDriver">最新驱动：</system:String>
+    <system:String x:Key="DriverUpdateLatestDriverValue">占位符</system:String>
+    <system:String x:Key="DriverUpdateInstalledDriverType" xml:space="preserve">已安装的驱动类型：         {0}</system:String>
+    <system:String x:Key="DriverUpdateUsedWindowsVersion" xml:space="preserve">已安装的 Windows 版本：         {0}</system:String>
+    <system:String x:Key="DriverUpdateImportantInfoHeadline">重要信息：</system:String>
+
+    <system:String x:Key="DriverUpdateImportantInfoExplanation">
+        Nvidia 已在 2019 年 5 月正式放弃了对 3D Vision / 立体 3D 的支持，这意味着近期的 Geforce 显卡驱动包中不再包含立体 3D 驱动。
+        尽管未包含在驱动包中，但 3D Vision 仍然可以安装并且功能完全正常。
+        3D Fix Manager 会为您处理这部分工作，并恢复 3D Vision / 立体 3D 功能。
+    </system:String>
+
+    <FlowDocument x:Key="testDoku">
+        <Paragraph Foreground="red">test</Paragraph>
+    </FlowDocument>
+
+    <system:String x:Key="StereoDriverAlreadyInstalled">立体 3D 驱动已安装到您的系统上。您现在已准备好在 VR 中游玩了！</system:String>
+
+    <system:String x:Key="SaveProfileToRepo">您想要将配置文件更改应用到 Git 工作副本中吗？</system:String>
+
+    <!-- VR Splash Dialog -->
+    <FlowDocument x:Key="VrSplashDialog" FontFamily="SegeUI" FontSize="16" PagePadding="5">
+        <Paragraph Style="{DynamicResource LargeGreenTitle}">欢迎来到 HelixVision！</Paragraph>
+
+        <Paragraph>感谢您加入我们，踏上这场史诗般的立体 3D 冒险之旅。希望您能像我们一样享受它。</Paragraph>
+
+        <Paragraph>HelixVision 基于 NVidia 3D Vision 启动，它能够将任何游戏转换为立体图像。
+            这些立体图像通过从 
+            <Hyperlink NavigateUri="http://helixmod.blogspot.com">HelixMod 博客</Hyperlink> 下载的 Mod 进行修复，并安装在游戏目录中。
+            游戏的配置文件会被修改为最佳设置，且您的显卡驱动在游戏运行期间也会被动态修改。
+        </Paragraph>
+
+        <Paragraph Margin="0,0,0,28">就像任何 Mod 操作一样，您可能会偶尔遇到故障和问题，尤其是随着游戏、驱动和操作系统的更新。</Paragraph>
+
+        <Paragraph><Italic>我们随时为您提供帮助。</Italic>如果您遇到问题，请随时在 Steam 论坛寻求帮助。</Paragraph>
+
+        <Paragraph>
+            <Hyperlink NavigateUri="https://steamcommunity.com/app/1127310/discussions/">支持链接：HelixVision Steam 论坛</Hyperlink>
+        </Paragraph>
+
+        <Paragraph Style="{DynamicResource LargeGreenTitle}">入门指南：</Paragraph>
+
+        <List MarkerStyle="Decimal">
+            <ListItem>
+                <Paragraph Style="{DynamicResource ParagraphInList}">点击下方按钮安装 NVidia 3D Vision 驱动。</Paragraph>
+            </ListItem>
+            <ListItem>
+                <Paragraph Style="{DynamicResource ParagraphInList}">启动 SteamVR。如果需要，Mixed Reality 或 Oculus Home 将启动。</Paragraph>
+            </ListItem>
+            <ListItem>
+                <Paragraph Style="{DynamicResource ParagraphInList}">从左侧列表中选择一款游戏。已安装的游戏以粗体显示。</Paragraph>
+            </ListItem>
+            <ListItem>
+                <Paragraph Style="{DynamicResource ParagraphInList}">点击“在 VR 中启动 (Play in VR)”。游戏将以红蓝 3D 形式出现在您的显示器上，并在 VR 中镜像显示真实立体画面。</Paragraph>
+            </ListItem>
+            <ListItem>
+                <Paragraph Style="{DynamicResource ParagraphInList}">戴上您的头显，尽情享受华丽的立体 3D 吧。</Paragraph>
+            </ListItem>
+        </List>
+    </FlowDocument>
+
+    <!-- Close to System Tray Warning -->
+    <FlowDocument x:Key="CloseToTrayWarning">
+        <Paragraph Style="{DynamicResource SemiLargeGreenTitle}">信息：</Paragraph>
+
+        <Paragraph>应用程序现已最小化到系统托盘，并在那里以图标表示。图标上有
+            <Image Source="..\Images\Tray Icons\2d_icon.ico" Height="20" Width="20" VerticalAlignment="Bottom" RenderOptions.BitmapScalingMode="HighQuality"/>
+            或
+            <Image Source="..\Images\Tray Icons\3d_icon.ico" Height="20" Width="20 " VerticalAlignment="Bottom" RenderOptions.BitmapScalingMode="HighQuality"/>
+            的标签，这可以告诉您当前是否启用了 3D 模式。
+        </Paragraph>
+
+        <Paragraph>若要关闭应用程序，请右键单击图标并选择
+            <Bold>
+                <Italic>“关闭 (Close)”</Italic>
+            </Bold>。
+        </Paragraph>
+
+        <Paragraph>左键单击该图标即可将应用程序带回前台。</Paragraph>
+    </FlowDocument>
+
+    <system:String x:Key="DriverUpdateInstallProcedure">安装说明：</system:String>
+
+    <system:String x:Key="DriverUpdateInstallProcedureExplanation">
+        只需让 3D Fix Manager 安装所需的驱动程序即可。
+        在安装向导询问时，请点击“继续”按钮，并等待安装完成。这就行了。
+        如果您不小心取消了其中一个安装向导，也请不要担心。3D Fix Manager 会检查所有依赖项并自动安装缺失的组件。
+    </system:String>
+
+    <system:String x:Key="DriverUpdateSupportedDriversHeadline">最后一个官方支持的 3D Vision 驱动：</system:String>
+
+    <system:String x:Key="DriverUpdateSupportedDriversExplanation">
+        于 2019 年 4 月发布的 Geforce 驱动版本 425.31 是最后一个官方支持 3D Vision 的驱动。
+        如果较新的驱动即使通过 3D Fix Manager 自动安装也无法在立体 3D 中工作，请安装此驱动。
+    </system:String>
+
+    <system:String x:Key="StereoSetupError">错误：无法启用立体 3D，因为缺少 3D Vision 驱动。&#x0d;&#x0d;请安装您显卡驱动的旧版本 425.31。</system:String>
+    <system:String x:Key="DriverInstallFailed">驱动安装失败。</system:String>
+    <system:String x:Key="ControllerInstallFailed">安装 3D 控制器驱动失败。</system:String>
+    <system:String x:Key="DchFixInstallFailed">安装 DCH 修复失败。</system:String>
+
+    <!-- Driver update dialog simple-->
+    <system:String x:Key="DriverUpdateSimpleHeadline">您是否也想将显卡驱动更新到最新版本？</system:String>
+    <system:String x:Key="DriverUpdatePleaseChoose">请选择</system:String>
+    <system:String x:Key="DriverUpdateSimpleYesChoice">：如果您想将您的 Geforce 显卡驱动更新到最新版本（推荐）。</system:String>
+    <system:String x:Key="DriverUpdateSimpleNoChoice">：如果您想保留当前已安装的 Geforce 驱动。</system:String>
+    <system:String x:Key="DriverUpdateSimpleNote">无论如何，驱动的立体 3D 功能都会被恢复。</system:String>
+
+    <system:String x:Key="DriverRestore2d" xml:space="preserve">对于 2D 模式，建议撤销对显卡驱动的修改。&#x0d;&#x0d;我们强烈建议您这样做，因为使用诸如“Easy Anticheat”等反作弊软件的游戏，在检测到安装了修改过的驱动时，可能会导致您的游戏账号被封禁。&#x0d;&#x0d;您是否想要立即恢复原始的显卡驱动？</system:String>
+    <system:String x:Key="DriverRestoreCloseApp" xml:space="preserve">在关闭应用程序之前，建议撤销对显卡驱动的修改。&#x0d;&#x0d;某些使用“Easy Anticheat”等反作弊软件的游戏需要恢复为原始驱动。这类游戏可能会阻止您启动游戏，或者在最坏的情况下，您的账号可能会因使用了修改版驱动而被封禁。&#x0d;&#x0d;您是否想要立即恢复原始显卡驱动？</system:String>
+    <system:String x:Key="DriverHackPlay3d" xml:space="preserve">要以立体 3D 模式游玩此游戏，必须在显卡驱动上安装一个 Mod 修改。修改驱动的操作仅针对需要它的游戏，并且修改后的驱动仅在游戏运行时从游戏目录加载。&#x0d;&#x0d;该修改仅替换了显卡驱动中的一条指令，即可恢复 Windows 10 v.1903 及更高版本以及任意显卡驱动版本中的全面立体 3D 兼容性。&#x0d;&#x0d;警告：请注意，对于使用了反作弊保护软件（例如“Easy AntiCheat”）的在线游戏，修改驱动文件是违规的。为了避免游戏账号被封禁，强烈建议您仅将修改后的驱动用于单机游戏。&#x0d;&#x0d;&#x0d;您是否想要现在修改显卡驱动以获得完整的立体 3D 支持？</system:String>
+    <system:String x:Key="DriverHack3d" xml:space="preserve">为了在立体 3D 模式下进行游戏，必须在显卡驱动上安装一个 Mod 修改。&#x0d;&#x0d;该修改仅替换了显卡驱动中的一条指令，即可恢复 Windows 10 v.1903 及更高版本以及任意显卡驱动版本中的全面立体 3D 兼容性。&#x0d;&#x0d;警告：请注意，对于使用了反作弊保护软件（例如“Easy AntiCheat”）的在线游戏，修改驱动文件是违规的。为了避免游戏账号被封禁，强烈建议您仅将修改后的驱动用于单机游戏。&#x0d;&#x0d;&#x0d;您是否想要现在修改显卡驱动以获得完整的立体 3D 支持？</system:String>
+    <system:String x:Key="FallBackToLocalDriverHack" xml:space="preserve">错误：未能将全局驱动修改安装到 Windows 驱动程序存储中。&#x0d;&#x0d;您是否愿意将驱动修改安装到您的本地游戏文件夹中，以便在游戏启动时加载？(推荐)&#x0d;&#x0d;提示：您可以随时在“Nvidia 3D 设置”选项卡中切换本地或全局驱动修改（通过切换“通过 3dmigoto 应用驱动修改”选项）。</system:String>
+    <system:String x:Key="DriverHackErrorFixNotInstalled" xml:space="preserve">错误：未安装 3D 修复程序，这是加载驱动修改所必需的。&#x0d;&#x0d;请安装 3D 修复后重试。</system:String>
+    <system:String x:Key="GlobalDriverHackNotRecommended" xml:space="preserve">检测到您的显卡驱动被修改过，这是为了在 Windows 10 上实现立体 3D 完全兼容性而进行的。&#x0d;&#x0d;该驱动修改仍然在全局范围内处于激活状态，这会影响所有已安装的游戏，包括那些不需要该修改的游戏。建议您撤销此全局修改，转为从游戏目录中安装并加载修改后的显卡驱动。&#x0d;&#x0d;您是否想要立即恢复原始显卡驱动？</system:String>
+    <system:String x:Key="GlobalDriverHackNotRecommendedNoneDx11" xml:space="preserve">检测到您的显卡驱动被修改过，这是为了在 Windows 10 上实现立体 3D 完全兼容性而进行的。&#x0d;&#x0d;要在立体 3D 下游玩此游戏并不需要该修改，并且建议您撤销该修改。&#x0d;&#x0d;您是否想要立即撤销显卡驱动修改？</system:String>
+    <system:String x:Key="LocalDriverHackNotPossibleForHelixVision" xml:space="preserve">当运行 Windows 10 v.1903 或更高版本并且驱动版本高于 425.31 时，目前无法将游玩此 VR 大屏游戏所需的 Mod 修改安装到显卡驱动中。&#x0d;&#x0d;退回到驱动版本 425.31 肯定能起作用。&#x0d;&#x0d;我们正在努力寻找解决方案，对给您带来的不便深表歉意。</system:String>
+
+    <!-- 3D Vision driver restore dialog -->
+    <system:String x:Key="DriverRestoreHeadline">您的系统上未安装 3D Vision。您是否想要立即安装所需的驱动程序？</system:String>
+    <system:String x:Key="StereoDependencyMissing">您的系统上缺失一个或多个立体 3D 所需的驱动组件。您是否想要立即安装它们？</system:String>
+    <system:String x:Key="StereoDriver">立体 3D 驱动：</system:String>
+    <system:String x:Key="StereoDriverValue">占位符</system:String>
+    <system:String x:Key="StereoDllPatched">立体 3D 驱动 DLL 修复：</system:String>
+    <system:String x:Key="DchDriverFixInstalled">立体 3D 驱动 DCH 修复：</system:String>
+    <system:String x:Key="DchDriverFixInstalledValue">占位符</system:String>
+    <system:String x:Key="StereoDllPatchedValue">占位符</system:String>
+    <system:String x:Key="ControllerDriver">3D 控制器驱动：</system:String>
+    <system:String x:Key="ControllerDriverValue">占位符</system:String>
+    <system:String x:Key="Win10GeforceFixInstalled">Geforce 驱动 DLL 修复：</system:String>
+    <system:String x:Key="Win10GeforceFixInstalledValue">占位符</system:String>
+    <system:String x:Key="Win10GeforceFixInstallationFailed" xml:space="preserve">错误：&#x0d;&#x0d;在安装立体 3D 及更高版本所需的 Geforce 显卡驱动修改时发生了错误。</system:String>
+    <system:String x:Key="Win10GeforceFixInstallationCanceled" xml:space="preserve">安装立体 3D 所需的 Geforce 显卡驱动修改已被用户取消。</system:String>
+    <system:String x:Key="Win10GeforceFixInstallationProcessKillFailed" xml:space="preserve">错误：&#x0d;&#x0d;未能安装立体 3D 所需的 Geforce 显卡驱动修改。&#x0d;&#x0d;错误原因：未能关闭所有正在继续阻塞驱动 DLL 的进程。</system:String>
+    <system:String x:Key="Win10GeforceFixRestoreProcessKillFailed" xml:space="preserve">错误：&#x0d;&#x0d;未能将 Geforce 显卡驱动重置为原始版本。&#x0d;&#x0d;错误原因：未能关闭所有正在继续阻塞驱动 DLL 的进程。</system:String>
+    <system:String x:Key="Win10GeforceFixRestoreCanceled" xml:space="preserve">将 Geforce 显卡驱动重置为原始状态的操作已被用户取消。</system:String>
+    <system:String x:Key="Win10GeforceFixRestoreFailed" xml:space="preserve">错误：&#x0d;&#x0d;未能将 Geforce 显卡驱动重置为原始版本。</system:String>
+
+    <system:String x:Key="CloseBlockingProcessesForGeforceFix">为了应用对 Geforce 显卡驱动的修改，必须关闭以下进程：</system:String>
+    <system:String x:Key="CloseBlockingProcessesForRestore">为了恢复 Geforce 显卡驱动的原始版本，必须关闭以下进程：</system:String>
+    <system:String x:Key="CloseProcessesConfirmation">您是否想要现在关闭这些进程？</system:String>
+
+    <system:String x:Key="DriverNotRequired">不需要</system:String>
+    <system:String x:Key="DriverInstalled">已安装</system:String>
+    <system:String x:Key="DriverNotInstalled">未安装</system:String>
+
+    <system:String x:Key="DriverRestoreImportantInfoExplanation">3D Vision 驱动是显示立体 3D 游戏所必需的。
+        遗憾的是，自 2019 年 5 月 Nvidia 放弃对 3D Vision 的支持后，官方的 Geforce 驱动包中已不再包含此驱动。
+        尽管如此，3D Vision 仍然可以安装，并且能够像以前一样完美运行。
+        3D Fix Manager 会为您处理这部分工作，并恢复 3D Vision / 立体 3D 功能。
+    </system:String>
+
+    <system:String x:Key="DoNoShowDriverUpdateMessage">不再检查驱动程序更新</system:String>
+
+    <system:String x:Key="SearchGamesResult" xml:space="preserve">已安装游戏搜索完成。&#x0d;&#x0d;找到的游戏数：{0}</system:String>
+    <system:String x:Key="FixInstallWarning" xml:space="preserve">不建议为该游戏安装 3D 修复。&#x0d;&#x0d;您确定仍要安装修复吗？</system:String>
+    <system:String x:Key="WrapperInstallWarning" xml:space="preserve">不建议为该游戏安装 3D 封装器 (Wrapper)。&#x0d;&#x0d;您确定仍要安装该封装器吗？</system:String>
+    <system:String x:Key="AlternativeFixDialog" xml:space="preserve">此游戏有一个替代的 3D 修复。&#x0d;&#x0d;关于替代 3D 修复的信息：&#x0d;&#x0d;{0}&#x0d;&#x0d;&#x0d;您想要下载哪个版本的 3D 修复？</system:String>
+    <system:String x:Key="SliFixDialog" xml:space="preserve">此游戏有一个专为 SLI 系统优化的替代 3D 修复。&#x0d;&#x0d;&#x0d;您想要安装哪个版本的 3D 修复？</system:String>
+    <system:String x:Key="AddUniversalFixDialog" xml:space="preserve">{0} 有一个通用 3D 修复可用。&#x0d;&#x0d;您是否想要将其添加到修复配置中？</system:String>
+    <system:String x:Key="ErrorOpeningConfigPath" xml:space="preserve">错误：无法打开路径。</system:String>
+    <system:String x:Key="ErrorOpeningRegistryPath" xml:space="preserve">错误：找不到注册表路径。</system:String>
+    <system:String x:Key="WeblinkInvalid" xml:space="preserve">错误：未能下载 Helix 帖子。&#x0d;&#x0d;博客的链接无效。</system:String>
+    <system:String x:Key="WeblinkNotProvided" xml:space="preserve">错误：未能下载 Helix 帖子。&#x0d;&#x0d;请先提供一个指向 Helix 博客的有效链接。</system:String>
+    <system:String x:Key="ViewerNotFound" xml:space="preserve">错误：未找到 3D Vision 照片查看器 (Photo Viewer)。</system:String>
+    <system:String x:Key="HelixPostError" xml:space="preserve">错误：未能下载 Helix 帖子。</system:String>
+    <system:String x:Key="NativeResolutionUpscaling"  xml:space="preserve">为了获得最佳效果，您应该将画面缩放的目标分辨率设置为显示器的原生分辨率。&#x0d;&#x0d;您是否想要现在将其设置为原生分辨率？&#x0d;&#x0d;检测到的原生分辨率：</system:String>
+    <system:String x:Key="Install3dmigoto02">安装 3dmigoto：</system:String>
+    <system:String x:Key="InstallOpenGLwrapper">安装 OpenGL 封装器：</system:String>
+    <system:String x:Key="InstallHelixMod02">安装 HelixMod：</system:String>
+    <system:String x:Key="RemoveProfile">移除修复配置？</system:String>
+    <system:String x:Key="RemoveRepoProfile">您是否想要同时从 Git 工作副本中移除该配置文件？</system:String>
+
+    <system:String x:Key="IniReset" xml:space="preserve">所有 ini 设置均已重置为默认值。&#x0d;&#x0d;别忘了保存更改。</system:String>
+    <system:String x:Key="EnableStereoWarning" xml:space="preserve">要查看此立体图像，必须启用 Nvidia 立体 3D。
+
+您是否想要现在启用它并继续？
+  
+注意：若要使用此功能，显示器的桌面刷新率应设置为 120 Hz。
+        
+提示：在“Nvidia 3D 设置”选项卡中，您可以找到一个自动切换到 120 Hz 的选项（参见“3D 模式桌面刷新率”）。</system:String>
+    
+    <system:String x:Key="GameTitleEmpty">错误：游戏标题不能为空</system:String>
+    <system:String x:Key="SteamAppIdNotSet" xml:space="preserve">注意：您尚未为此配置设置 Steam App ID，而这是启动 Steam 游戏所必需的。&#x0d;&#x0d;您是否想要现在自动检测它？</system:String>
+    <system:String x:Key="GameExeNotSet" xml:space="preserve">注意：您尚未为该配置设置游戏 Exe。这通常是启动游戏所必需的。&#x0d;&#x0d;您是否想要现在自动检测它？</system:String>
+    <system:String x:Key="GamesDbIconDectection" xml:space="preserve">您是否想要从 TheGamesDB.com 自动添加一个游戏图标？</system:String>
+    <system:String x:Key="WrapperChoice" xml:space="preserve">选择您想要安装的 3D 封装器 (Wrapper)。
+                                         
+安装封装器将解锁某些功能，如立体 3D 快捷键、并排或上下输出模式 (SideBySide / TaB)、支持兼容模式以及自动安装驱动配置。
+        
+注意：
+        
+- 为 DirectX 9 游戏安装 HelixMod
+- 为 OpenGL 游戏安装 OpenGL Wrapper
+- 为 DirectX 11 游戏安装 3dmigoto
+- 确保您选择正确的版本（32 位 或 64 位）
+  如果已将游戏启动器 Exe 添加到修复配置中，系统会自动检测该信息
+- 此操作仅安装原生封装器（不包含 Shader 修复）</system:String>
+
+    <system:String x:Key="ErrorGameAlreadyExists">错误：已存在具有相同标题的配置文件。</system:String>
+    <system:String x:Key="GameIconFileNotFound">错误：未找到游戏图标文件。</system:String>
+    <system:String x:Key="InstallPathNotRelative">错误：安装路径不是相对路径。</system:String>
+    <system:String x:Key="IniPathNotRelative">错误：游戏 ini 路径不是相对路径。</system:String>
+    <system:String x:Key="AdditionalIniPathNotRelative">错误：额外的游戏 ini 路径不是相对路径。</system:String>
+    <system:String x:Key="ChangesSaved">更改已成功保存。</system:String>
+    <system:String x:Key="ErrorSavingProfile">错误：保存对配置文件的更改时出了点问题。</system:String>
+    <system:String x:Key="FixProfileCreated">已成功创建修复配置。</system:String>
+    <system:String x:Key="IconResetSuccessfull" xml:space="preserve">所有图标均已成功重置并在后台完成下载。&#x0d;&#x0d;注意：所有旧图标已被移动到各配置文件夹内的一个备份文件夹中，以便在需要时进行恢复。</system:String>
+    <system:String x:Key="ServerNotAvailable" xml:space="preserve">服务器不可用。&#x0d;&#x0d;请稍后再试。</system:String>
+    <system:String x:Key="FixUpdatesAvailable" xml:space="preserve">有新的修复配置可用。您要更新吗？</system:String>
+    <system:String x:Key="FixUpdateAvailable" xml:space="preserve">游戏“{0}”有更新的 3D 修复。&#x0d;&#x0d;您是否想要立即更新到最新版本？&#x0d;&#x0d;注意：在此过程中，旧的修复程序会自动卸载，然后再下载并安装新的修复程序。自定义的快捷键将被保留。</system:String>
+    <system:String x:Key="NoUpdates" xml:space="preserve">没有可用的程序更新。&#x0d;&#x0d;修复配置已是最新。</system:String>
+    <system:String x:Key="ProgramUpdateAvailable" xml:space="preserve">有新版本的 3D Fix Manager 可用。您要更新吗？</system:String>
+    <system:String x:Key="BugReportTo" xml:space="preserve">如果您想报告错误 (Bug) 或对新功能有任何想法，请发送电子邮件至：&#x0d;&#x0d;duselpaul86@gmx.de</system:String>
+    <system:String x:Key="NoChangeNotesFound">抱歉，未找到更新日志。</system:String>
+    <system:String x:Key="ChangeNotesManager">3D Fix Manager 更新日志：</system:String>
+    <system:String x:Key="ChangeNotesProfiles">修复配置更新日志：</system:String>
+    <system:String x:Key="WarningRootPath">警告：选择硬盘的根目录可能会导致极其漫长的加载时间。</system:String>
+    <system:String x:Key="WarningSearchDepth" xml:space="preserve">警告：较高的搜索深度数值可能会导致极其漫长的加载时间。&#x0d;&#x0d;请尽量保持该数值在最低程度（不高于 2）。</system:String>
+    <system:String x:Key="ErrorNotNumber">错误：输入内容不是数字。</system:String>
+    <system:String x:Key="RTSSPauseMessage" xml:space="preserve">游戏启动已暂停 - 如有需要，请更改 RivaTuner Statistics Server 的设置。
+RTSS 能消除微小卡顿，降低输入延迟，并改善 3D 模式下的帧生成时间。
+
+RivaTuner Statistics Server 6.6.0 推荐设置：
+        
+- Custom Direct3D support (自定义 Direct3D 支持)：关
+- Framerate limit (帧率限制)：60
+
+当游戏崩溃或帧率限制器未生效时，请开启 Custom Direct3D support。
+
+为达到完美效果，您需要在游戏中启用垂直同步 (Vsync)，且显卡性能必须能稳定保持在 60 fps。
+
+更改完毕后，点击“确定”。</system:String>
+    <system:String x:Key="DownloadFixBeforeGameStart" xml:space="preserve">建议在启动此游戏前安装 3D 修复。&#x0d;&#x0d;您想要现在安装此修复吗？</system:String>
+    <system:String x:Key="MessageRestore2DProfile" xml:space="preserve">建议在卸载修复时恢复原始驱动配置“{0}”。&#x0d;&#x0d;您是否想要立即重置驱动配置？</system:String>
+    <system:String x:Key="MessageRestore2DProfileSwap" xml:space="preserve">建议在卸载修复时恢复原始驱动配置。为此，必须将当前分配的配置“{0}”替换为驱动配置“{1}”。&#x0d;&#x0d;您是否想要立即替换配置文件？&#x0d;&#x0d;如果配置已被替换，您可选择“否”跳过此步骤。</system:String>
+    <system:String x:Key="MessageProfile2D" xml:space="preserve">建议在 2D 模式游玩时使用默认驱动配置“{0}”。&#x0d;&#x0d;您是否想要立即将驱动配置重置为原始状态？&#x0d;&#x0d;如果您已重置了配置，可选择“否”跳过此步骤。</system:String>
+    <system:String x:Key="MessageProfile2DSwap" xml:space="preserve">建议在 2D 模式游玩时使用默认驱动配置。为此，必须将当前分配的配置“{0}”替换为驱动配置“{1}”。&#x0d;&#x0d;您是否想要立即替换配置文件？&#x0d;&#x0d;如果配置已被替换，您可选择“否”跳过此步骤。</system:String>
+    <system:String x:Key="MessageProfile3D" xml:space="preserve">需要安装驱动配置“{0}”才能使修复程序正常工作。&#x0d;&#x0d;您是否想要立即通过 Nvidia Profile Inspector 安装它？&#x0d;&#x0d;如果您已安装过该配置，可选择“否”跳过此步骤。</system:String>
+    <system:String x:Key="MessageProfile3DSwap" xml:space="preserve">必须将当前分配的驱动配置“{0}”替换为配置“{1}”才能使修复程序正常工作。&#x0d;&#x0d;您是否想要立即通过 Nvidia Profile Inspector 替换配置文件？&#x0d;&#x0d;如果配置已被替换，您可选择“否”跳过此步骤。</system:String>
+    <system:String x:Key="ErrorGameLaunch">错误：游戏无法启动。</system:String>
+    <system:String x:Key="ErrorOpenWebsite">错误：无法打开网站。</system:String>
+    <system:String x:Key="ReferenceDataDbSuccess">参考数据已成功写入数据库。</system:String>
+    <system:String x:Key="DbNoRights">错误：没有访问数据库的权限。</system:String>
+    <system:String x:Key="WarningPositiveNumber">警告：输入内容必须为正数。</system:String>
+    <system:String x:Key="ErrorInputNotANumber">错误：输入内容不是数字。</system:String>
+    <system:String x:Key="ErrorLicenceNotice">抱歉，未找到许可文件。</system:String>
+    <system:String x:Key="UpdateMigoto" xml:space="preserve">您想将 3dmigoto 更新至最新版本吗？&#x0d;&#x0d;已安装版本：&#x09;</system:String>
+    <system:String x:Key="LatestVersion" xml:space="preserve">最新版本：&#x09;</system:String>
+    <system:String x:Key="MigotoUpdateSuccess">3dmigoto 已成功更新。</system:String>
+    <system:String x:Key="MigotoUpdateFailed">错误：未能更新 3dmigoto。</system:String>
+    <system:String x:Key="ErrorEnablingCM">在启用 / 禁用兼容性模式时发生错误。</system:String>
+    <system:String x:Key="UpdateMigoto02" xml:space="preserve">此功能仅在 3dmigoto 版本高于 1.2.48 时可用。&#x0d;&#x0d;您是否想将 3dmigoto 更新到最新版本？&#x0d;&#x0d;已安装版本：&#x09;</system:String>
+    <system:String x:Key="UpdateMigotoDueTo3dFormat" xml:space="preserve">在当前处于激活状态的显示器配置中，您选择了仅在 3dmigoto 版本 1.2.65 及以上支持的 3D 格式，因此需要更新该 3D 封装器。&#x0d;&#x0d;您是否想要立即更新 3dmigoto 以启用此 3D 格式？&#x0d;&#x0d;已安装版本：&#x09;</system:String>
+    <system:String x:Key="DonateMessage" xml:space="preserve">如果您想支持此项目，可以通过向该 PayPal 账号捐款：duselpaul86@gmx.de
+
+点击下方按钮，您的浏览器将打开 PayPal 网站，您可以轻松进行捐赠。
+        
+请帮助我们让 3D 游戏能够长远发展。
+        
+谢谢大家，
+Markus Gündert (Pauldusler)</system:String>
+    <system:String x:Key="DonateShaderHackers01">由 3D Fix Manager 下载并安装的 3D 修复程序均由来自 HelixMod 团队的一群极具才华的 Shader 开发者（大神）所开发。</system:String>
+    <system:String x:Key="DonateShaderHackers02">HelixMod 是 3D 游戏至今依然充满活力的原因。如果您想支持他们，我们非常感激您的捐款。</system:String>
+    <system:String x:Key="DonateShaderHackers03">以下是各位 Shader 开发者的 PayPal 和 Patreon 账户列表，您可以向他们捐款：</system:String>
+    <system:String x:Key="Thanks">非常感谢您，</system:String>
+    <system:String x:Key="YourHelixModTeam">您的 HelixMod 团队</system:String>
+    <system:String x:Key="YourHelixModTeam02">您的 HelixMod 团队</system:String>
+    <system:String x:Key="OpenPaypal">打开 PayPal</system:String>
+    <system:String x:Key="OpenPaypalToolTip">在浏览器中打开 PayPal 网站，您可以在那里进行捐款。</system:String>
+
+    <!-- Nvidia 3D Vision announcement - Start -->
+    <system:String x:Key="Announcement_L1">亲爱的 3D Vision 粉丝们：</system:String>
+    <system:String x:Key="Announcement_L2">我们要宣布一个不幸的消息。在 2019 年 3 月 8 日，Nvidia 正式宣布终止对 3D Vision 的支持。</system:String>
+    <system:String x:Key="Announcement_L3">这意味着 2019 年 3 月之后发布的所有显卡驱动将不再支持 3D Vision。</system:String>
+    <system:String x:Key="Announcement_L4">418 系列驱动将是最后一个支持立体 3D 的版本分支。</system:String>
+
+    <system:String x:Key="Announcement_L5">这项声明对我们 3D 玩家意味着什么？</system:String>
+    <system:String x:Key="Announcement_L6">我们不得不坚持使用 418 系列或更老版本的 Geforce 驱动（v.419.35 仍可使用，因为它仍属于 418 分支）。</system:String>
+    <system:String x:Key="Announcement_L7">我们不应该将 Windows 10 更新至超过 v.1809 的版本（2018 年十月更新）。Win 10 的新功能更新可能会破坏立体 3D 驱动。</system:String>
+    <system:String x:Key="Announcement_L8">我们必须好好爱护自己的 3D Vision 硬件，因为未来如果设备损坏将很难找到替换品。</system:String>
+
+    <system:String x:Key="Announcement_L9">这对 3D Fix Manager 意味着什么？</system:String>
+    <system:String x:Key="Announcement_L10">没有任何影响。我们将继续对 3D Fix Manager 提供支持。</system:String>
+    <system:String x:Key="Announcement_L11">如果您安装了超过 418 分支的 Geforce 驱动，3D Fix Manager 会向您发出警告。</system:String>
+    <system:String x:Key="Announcement_L12">在这种情况下，3D Fix Manager 将为您提供兼容 3D Vision 的最后一个已知驱动版本的下载链接。</system:String>
+
+    <system:String x:Key="Announcement_L13">这对新 3D 修复的开发意味着什么？</system:String>
+    <system:String x:Key="Announcement_L14">只要 Shader 开发大神们的 3D Vision 硬件还能正常工作，开发新的 3D 修复程序就极有可能会继续下去。</system:String>
+
+    <system:String x:Key="Announcement_L15">这对立体 3D 的未来意味着什么？</system:String>
+    <system:String x:Key="Announcement_L16">目前，我们出色的社区开发者正在讨论开发一个不再需要 3D Vision 驱动的独立 3D 解决方案。</system:String>
+    <system:String x:Key="Announcement_L17">目前机会还不错，因为 3dmigoto 中已经实现了实现这一目标所需的诸多功能。</system:String>
+    <system:String x:Key="Announcement_L18">但是：在编写这段文字的当下，我们还无法给出任何保证！</system:String>
+
+    <system:String x:Key="Announcement_L19">Nvidia 官方声明：</system:String>
+    <system:String x:Key="Announcement_L20">如需了解更多信息，我们在 Geforce 论坛上开设了一个话题：</system:String>
+    <system:String x:Key="Announcement_DoNotShow">不再显示此对话框</system:String>
+    <!-- Nvidia 3D Vision announcement - End -->
+
+    <!-- Nvidia driver check - Start -->
+    <system:String x:Key="Drivercheck_1">警告：您的 Nvidia 显卡驱动与 3D Vision 不兼容。</system:String>
+    <system:String x:Key="Drivercheck_2">在 2019 年 3 月 8 日，Nvidia 正式宣布终止对 3D Vision 的支持。</system:String>
+    <system:String x:Key="Drivercheck_3">为了让 3D Vision 正常工作，您必须安装旧版显卡驱动。</system:String>
+    <system:String x:Key="Drivercheck_4">在下方，您可以找到最后一个已知能与 3D Vision 兼容的 Geforce 驱动的下载链接：</system:String>
+    <system:String x:Key="Drivercheck_5">请注意，此驱动可能无法在 Windows 10 的未来版本中正常运行。该驱动发布于 Windows 10 v.1809 (2018 年十月更新) 时期，因此不建议在更新版本的 Windows 上使用。</system:String>
+    <!-- Nvidia driver check - End -->
+
+    <system:String x:Key="ReleaseBuildSucces">成功：发布版文件已成功生成。</system:String>
+    <system:String x:Key="ReleaseBuildFailed">错误：发布流程失败。</system:String>
+    <system:String x:Key="DuplicateKeyError" xml:space="preserve">错误：此快捷键已存在。&#x0d;&#x0d;请选择其他按键。</system:String>
+    <system:String x:Key="FolderNotExistsError">错误：文件夹不存在。</system:String>
+    <system:String x:Key="SettingsAppliedSuccess">设置已成功应用。</system:String>
+    <system:String x:Key="SettingsAppliedFailed">错误：未能应用设置。</system:String>
+    <system:String x:Key="ProfileLoadedSuccess" xml:space="preserve">配置文件加载成功。&#x0d;&#x0d;请点击“应用”将导入的值写入 Windows 注册表。</system:String>
+    <system:String x:Key="ProfileLoadedSuccess02">配置文件加载成功。</system:String>
+    <system:String x:Key="ProfileLoadedError">错误：配置文件无法加载。</system:String>
+    <system:String x:Key="ProfileSavedSuccess">配置文件保存成功。</system:String>
+    <system:String x:Key="ProfileSavedError">错误：配置文件无法保存。</system:String>
+    <system:String x:Key="ValidUrlError">错误：必须提供有效的 Url。</system:String>
+    <system:String x:Key="MultiRowHyperlinkError">错误：超链接不允许进行多行选择。</system:String>
+    <system:String x:Key="UpdateAllWrappersMessage" xml:space="preserve">这将把所有已安装的 3dmigoto 修复更新为该封装器的最新版本。&#x0d;&#x0d;您想要继续吗？</system:String>
+    <system:String x:Key="AllUpdatesInstalled">成功！已为 {0} 个游戏更新 3dmigoto。</system:String>
+    <system:String x:Key="MigotoAlreadyUpdated">所有游戏的 3dmigoto 已是最新。不需要进行更新。</system:String>
+    <system:String x:Key="TypeTitleError">错误：请先输入游戏标题。</system:String>
+    <system:String x:Key="FoundSteamDbData">找到 Steam 数据库数据：</system:String>
+    <system:String x:Key="GameExe">游戏 Exe：</system:String>
+    <system:String x:Key="RelativeGameExePath">游戏 Exe 的相对路径：</system:String>
+    <system:String x:Key="ApplyData">您是否想要将此数据应用到修复配置中？</system:String>
+    <system:String x:Key="NotFoundInDb">在 Steam 数据库中找不到匹配的游戏</system:String>
+    <system:String x:Key="NoSteamAppId">错误：必须提供有效的 SteamApp ID。</system:String>
+    <system:String x:Key="NotFoundInTheGamesDb">在 TheGamesDb 数据库中找不到匹配的游戏。</system:String>
+    <system:String x:Key="IconUrlNotFound">未找到图标的 URL。</system:String>
+    <system:String x:Key="WarningMigotoUpdate01">警告：更新 3dmigoto 对应</system:String>
+    <system:String x:Key="WarningMigotoUpdate02" xml:space="preserve">已知会破坏该修复。&#x0d;&#x0d;您是否仍要为该游戏更新封装器？</system:String>
+    <system:String x:Key="ErrorIniReadOnly" xml:space="preserve">在更改游戏 ini 文件时发生错误。&#x0d;&#x0d;请确保文件未被设置为“只读”。</system:String>
+    <system:String x:Key="WarningWatchDogs2" xml:space="preserve">警告：安装《看门狗 2 (Watch_Dogs 2)》的修复可能需要长达 10 分钟。&#x0d;&#x0d;您想要继续吗？</system:String>
+    <system:String x:Key="ErrorInstallingMinecraft">安装 Minecraft 修复时发生错误。修复未能安装。</system:String>
+    <system:String x:Key="ErrorDeleting2DNip">错误：无法删除 2D 模式的 .nip 文件。</system:String>
+    <system:String x:Key="ErrorDeleting3DNip">错误：无法删除 3D 模式的 .nip 文件。</system:String>
+    <system:String x:Key="ErrorEnablingSteamOverlay">错误：无法启用 / 禁用 Steam 覆盖层。</system:String>
+    <system:String x:Key="ErrorJavaNotDetected" xml:space="preserve">错误：无法检测到 Java 的安装位置。请确保您已正确安装 Java。&#x0d;&#x0d;您想要现在前往 Java 的下载页面吗？</system:String>
+    <system:String x:Key="ErrorOptifineNotDetected" xml:space="preserve">错误：无法检测到 Minecraft 的 Optifine。您必须先安装它才能继续安装 3D 修复。\n\n您想要现在前往 Optifine 的下载页面吗？</system:String>
+    <system:String x:Key="ErrorDetectingBitVersion">错误：无法检测安装的 Java 是 64 位还是 32 位。</system:String>
+    <system:String x:Key="ErrorInstallingMinecraftFix">安装 Minecraft 修复时发生错误。</system:String>
+    <system:String x:Key="ErrorRenamingHitmanFolder">错误：无法重命名 Hitman 文件夹。请确保在 Windows 资源管理器中该文件夹处于关闭状态，然后重试。</system:String>
+
+    <system:String x:Key="KeepCustomProfiles" xml:space="preserve">您想保留自定义的配置吗？&#x0d;&#x0d;如果您编辑了部分配置并想要保留这些更改，请选择“是”。&#x0d;&#x0d;如果您想覆盖所有旧配置的设置，请选择“否”。</system:String>
+    <system:String x:Key="MigotoUpdateAvailable" xml:space="preserve">一个或多个已安装的 3D 修复有可用的 3dmigoto 更新。&#x0d;&#x0d;您是否想要立即更新？</system:String>
+    <system:String x:Key="BindHotkeyError" xml:space="preserve">错误：一个或多个快捷键未绑定任何按键。&#x0d;&#x0d;请设置按键后重试。</system:String>
+    <system:String x:Key="DownloadProgramComplete" xml:space="preserve">下载完成！&#x0d;&#x0d;3D Fix Manager 现在将重启以安装更新。</system:String>
+    <system:String x:Key="VisionNotSetup" xml:space="preserve">您的计算机上未设置 3D Vision。&#x0d;&#x0d;选项 1：点击“设置向导”启动默认的 Nvidia 3D Vision 设置向导。&#x0d;&#x0d;选项 2：点击“快速设置”通过修改 Windows 注册表值快速启用 3D Vision。&#x0d;&#x0d;</system:String>
+    <system:String x:Key="VisionSetupComplete" xml:space="preserve">3D Vision 设置向导成功完成！&#x0d;&#x0d;您是否想要加载备份配置文件以恢复快捷键和其他立体 3D 相关的设置？</system:String>
+    <system:String x:Key="LoadStereoProfile" xml:space="preserve">您是否想要加载备份过的配置文件以恢复立体 3D 设置？</system:String>
+    <system:String x:Key="WindowsRegistryWriteError">错误：无法将加载的设置配置写入 Windows 注册表。</system:String>
+    <system:String x:Key="DefaultWizardSkipped" xml:space="preserve">默认的设置向导已成功跳过，且 3D Vision 已启用。&#x0d;&#x0d;您是否想要加载备份配置文件以恢复快捷键和其他立体 3D 相关的设置？</system:String>
+    <system:String x:Key="QuickSetupError">在启用 Nvidia 立体 3D 时出错。请尝试使用默认设置向导代替。</system:String>
+
+    <system:String x:Key="ForceAnaglyphError">错误：无法强制开启 3D Vision Discover (红蓝 3D)。</system:String>
+    <system:String x:Key="Force3dVisionError">错误：无法强制开启 3D Vision / Generic CRT (主动式 3D)。</system:String>
+    <system:String x:Key="Force3dtvPlayError">错误：无法强制开启 3DTV Play。</system:String>
+    <system:String x:Key="ForceCheckerboard">错误：无法强制开启棋盘格 (Checkerboard, 主动式 3D)。</system:String>
+    <system:String x:Key="ForceReversedCheckerboard">错误：无法强制开启反转棋盘格 (Reversed Checkerboard, 主动式 3D)。</system:String>
+    <system:String x:Key="ForceLineInterlacingError">错误：无法强制开启行交错 (LineInterlacing, 被动式 3D)。</system:String>
+    <system:String x:Key="ForceReversedLineInterlacingError">错误：无法强制开启反转行交错 (Reversed LineInterlacing, 被动式 3D)。</system:String>
+     
+    <system:String x:Key="DepthHackError">错误：3D 深度 Hack 无法应用 / 移除。</system:String>
+    <system:String x:Key="WritePermissionError">错误：无法在 Windows 注册表中为 Stereo3D 键值设置“System”用户的写入权限。</system:String>
+    <system:String x:Key="AllFixesDisabled">成功！所有已安装的 3D 修复均已禁用，并且在下次启动游戏时不再处于激活状态。</system:String>
+    <system:String x:Key="AllFixesEnabled">成功！所有已安装的 3D 修复均已启用。</system:String>
+    <system:String x:Key="EnableNvidia3dDriverOverlayError">错误：未能启用 3D 驱动覆盖层。</system:String>
+    <system:String x:Key="DisableNvidia3dDriverOverlayError">错误：未能禁用 3D 驱动覆盖层。</system:String>
+    <system:String x:Key="EnableNvidia3dDriverOverlaySuccess" xml:space="preserve">3D 驱动覆盖层已成功启用。&#x0d;&#x0d;请重新启动您的系统以使更改生效。</system:String>
+    <system:String x:Key="DisableNvidia3dDriverOverlaySuccess" xml:space="preserve">3D 驱动覆盖层已成功禁用。&#x0d;&#x0d;请重新启动您的系统以使更改生效。</system:String>
+
+    <system:String x:Key="SwitchTo3dVisionWarning" xml:space="preserve">警告：您正在切换至 3D Vision 模式。&#x0d;&#x0d;该模式仅适合使用受支持的 3D 显示器进行游玩。&#x0d;&#x0d;如果您想在虚拟现实 (VR) 的大屏幕上游玩，请从列表中选择“VR”。</system:String>
+
+
+    <!--....................  Dialog Window End .......................... -->
+
+
+    <!-- XAML formated ToolTips Begin -->
+
+    <!-- Installation Tab ToolTips -->
+    <TextBlock x:Key="ForceCMToolTip" TextWrapping="Wrap" Width="300">
+        通过自动修改驱动配置文件，强制 DirectX 11 游戏以兼容性模式 (也称为伪 3D) 启动。<LineBreak/><LineBreak/>
+        如果兼容模式的画面看起来不对，请转到<Italic><Bold>“快捷键”</Bold></Italic>选项卡，在<Italic><Bold>“驱动配置设置”</Bold></Italic>部分中为<Italic><Bold>“2DDHUDSettings”</Bold></Italic>选择另一个值。
+    </TextBlock>
+
+    <TextBlock x:Key="EnableCmuToolTip" TextWrapping="Wrap" Width="300">
+       启用<Bold>兼容模式解锁版 (CMU)</Bold>。<LineBreak/><LineBreak/>    
+       CMU 仅在 DirectX 11 游戏中可用，它使得那些尚未修复为真实 3D 的游戏也能在立体 3D 下游玩。<LineBreak/><LineBreak/>
+       CMU 的另一个优势是它需要较少的性能就能在 3D 下获得流畅的游戏体验。<LineBreak/><LineBreak/>
+       不过，与传统 3D 相比，此模式会遇到 3D 伪影（如物体周围出现光晕），且默认情况下 3D 深度受限更严重。<LineBreak/><LineBreak/>
+       <Bold>重要信息：</Bold> 在游戏中按 <Bold>F11</Bold> 或 <Bold>F12</Bold>（默认配置）以“解锁” CMU，从而突破最大 3D 深度并改善 3D 效果。<LineBreak/><LineBreak/>
+       此外，在<Bold>“3D 修复”</Bold>选项卡中，您可以找到配置 CMU 的选项。
+    </TextBlock>
+    
+    <TextBlock x:Key="EnableFixToolTip" TextWrapping="Wrap" Width="300">
+        手动启用 / 禁用 3D 修复。<LineBreak/><LineBreak/>
+        <Bold>注意：</Bold> 当点击<Italic><Bold>“启动 2D 模式”</Bold></Italic>或<Italic><Bold>“启动 3D 模式”</Bold></Italic>按钮时，也会自动完成 3D 修复的启用/禁用操作。
+    </TextBlock>
+
+    <TextBlock x:Key="InstallFixTooltip" TextWrapping="Wrap" Width="300">
+        <Bold>左键单击：</Bold> 安装 / 卸载 3D 修复。<LineBreak/><LineBreak/>
+        <Bold>右键单击：</Bold> 如果 3dmigoto 已经被更新，将其重置为该 3D 修复原始随附的版本。如果更新 3dmigoto 破坏了修复，请使用此功能。
+    </TextBlock>
+
+    <!-- New / Edit Profile Tab ToolTips -->
+    <TextBlock x:Key="GameTitleToolTip" TextWrapping="Wrap" Width="300">
+        <Bold>游戏标题</Bold>必须与 Steam 库中列出的名称，或与“Windows 控制面板 / 程序和功能”中已安装程序的列表名称一致。<LineBreak/><LineBreak/>
+        请检查右侧的列表以查看 3D Fix Manager 从 Windows 注册表中检测到的所有已安装程序。选择一个程序可将其名称应用为游戏标题。
+    </TextBlock>
+
+    <TextBlock x:Key="RelativeInstallPathToolTip" TextWrapping="Wrap" Width="300">
+        输入游戏目录子文件夹的相对路径，3D Vision 修复将被复制到此位置。<LineBreak/><LineBreak/>
+        在大多数情况下，正确的安装路径是用于启动游戏的 Game Exe (执行文件) 所在的文件夹。<LineBreak/><LineBreak/>
+        <Bold>例如：</Bold> 如果游戏 exe 的绝对路径为<Italic>“c:\gameTitle\bin\game.exe”</Italic>，那么生成的相对安装路径就是<Italic>“bin”</Italic>。<LineBreak/><LineBreak/>
+        如果要将修复安装到游戏的根文件夹中，请将此字段留空。<LineBreak/><LineBreak/>
+        <Bold>重要提示：</Bold> 如果游戏执行文件位于游戏的子目录中，相对安装路径也用于查找该执行文件。在这种情况下，即使您不打算安装 3D 修复，也必须填写此字段。
+    </TextBlock>
+
+    <TextBlock x:Key="GameDirNameToolTip" TextWrapping="Wrap" Width="300">
+        填入游戏的安装文件夹 / 根文件夹名称（仅填写文件夹名称，不包括路径）。<LineBreak/><LineBreak/>
+        此信息对于通过搜索路径检测游戏非常重要。
+    </TextBlock>
+
+    <TextBlock x:Key="CustomRootPathToolTip" TextWrapping="Wrap" Width="300">
+        仅当 3D Fix Manager 无法自动检测到已安装的游戏时才填写此字段。<LineBreak/><LineBreak/>
+        选择游戏根文件夹的绝对路径。<LineBreak/><LineBreak/>
+        注意：如果您想将修复安装在游戏的子文件夹中，仍必须设置“相对安装路径”。
+    </TextBlock>
+
+    <TextBlock x:Key="RelativeGameIniPathToolTip" TextWrapping="Wrap" Width="500">
+        输入游戏<Bold>配置文件</Bold>（例如 .ini 或 .cfg 文件）的相对路径，该文件将根据为 2D 或 3D 模式定义的值自动进行编辑。相对路径必须从游戏的<Bold>根路径</Bold>或 <Italic>C:\Users\用户名</Italic> 下的<Bold>用户文件夹</Bold>开始设置——这两个目录会被用于搜索指定的配置文件。<LineBreak/><LineBreak/>
+        此功能的主要目的是在启动游戏时自动编辑图形设置（例如禁用不需要在立体 3D 模式下出现的<Bold>运动模糊 (Motion blur)</Bold>或<Bold>景深 (Depth of field)</Bold>）。<LineBreak/><LineBreak/>
+        通常，任何包含键/值对列表的配置文件都可以进行编辑——在文件中的格式可能像这样：<Italic><Bold>MotionBlur = Off</Bold></Italic>。<LineBreak/><LineBreak/>
+        您可以查看游戏<Italic><Bold>“Outlast”</Bold></Italic>的修复配置，作为一个如何编辑配置文件的示例。<LineBreak/><LineBreak/>
+        单击<Italic><Bold>“2D 模式参数”</Bold></Italic>按钮可定义配置文件的键值对。在 2D 模式下启动游戏或卸载修复时，将设置这些键。<LineBreak/><LineBreak/>
+        同样，当单击<Italic><Bold>“3D 模式参数”</Bold></Italic>按钮时也是如此。在 3D 模式下启动游戏或安装修复时，将应用其中定义的键。
+    </TextBlock>
+
+    <TextBlock x:Key="HelixPostUpdatedToolTip" TextWrapping="Wrap" Width="300">
+       保存 Helix 帖子最后更新的日期。<LineBreak/><LineBreak/>
+       时间戳对于检测网络上是否有更新版本的 Helix 帖子非常必要。<LineBreak/><LineBreak/>
+       您不应该手动设置此日期，因为它是自动完成的。
+    </TextBlock>
+
+    <TextBlock x:Key="AllowHelixPostUpdateToolTip" TextWrapping="Wrap" Width="300">
+        设置当 <Italic>helixmod.blogspot.com</Italic> 上的博客帖子被编辑时，是否自动更新此配置的说明文本。
+    </TextBlock>
+
+    <TextBlock x:Key="InfoAlternativeUrlToolTip" TextWrapping="Wrap" Width="300">
+        如果游戏有替代的 3D 修复可用，您可在此提供关于此修复的附加信息。<LineBreak/><LineBreak/>
+       <Bold>自定义信息文本：</Bold> 在安装 3D 修复时显示一段信息文本，告知用户有关替代 3D 修复的存在。您可以在文本字段中输入自定义文本。<LineBreak/><LineBreak/>
+       <Bold>SLI 信息文本：</Bold> 在安装 3D 修复时显示预定义的信息文本，告知用户存在一个专为 SLI 系统优化的替代 3D 修复。
+    </TextBlock>
+
+    <TextBlock x:Key="DownloadLinkFixToolTip" TextWrapping="Wrap" Width="300">
+        3D Vision 修复的直接下载链接。
+    </TextBlock>
+
+    <TextBlock x:Key="AdditionalDownloadLinkFixToolTip" TextWrapping="Wrap" Width="300">
+        如果 3D Vision 修复分为了多个下载链接，请在此提供额外的下载链接。
+    </TextBlock>
+
+    <TextBlock x:Key="Allow3dFixInstallationToolTip" TextWrapping="Wrap" Width="300">
+        将此项设为<Italic><Bold>“否”</Bold></Italic>可以警告用户不要安装该 3D 修复或 3D 封装器。<LineBreak/><LineBreak/>
+        通过这样做，用户被告知已不再强制需要安装该修复，但如有需要仍然可以安装。
+    </TextBlock>
+
+    <TextBlock x:Key="Allow3dMigotoUpdateToolTip" TextWrapping="Wrap" Width="300">
+        如果新版 3dmigoto 与现有的 3D 修复不兼容，请将此选项设置为<Italic><Bold>“否”</Bold></Italic>。这样做会在用户更新该封装器之前发出警告。
+    </TextBlock>
+
+    <TextBlock x:Key="StereoRefreshRateOverrideToolTip" TextWrapping="Wrap" Width="300">
+        如果您的电脑性能不足以在玩立体 3D 游戏时维持稳定的 120 帧，请将此选项设置为 100 Hz。<LineBreak /><LineBreak />
+        当设为 100 Hz 时，只需 100 fps 即可获得流畅的游戏体验。<LineBreak /><LineBreak />
+        此选项仅在<Italic><Bold>“常规设置”</Bold></Italic>选项卡中启用了<Italic><Bold>“刷新率由修复配置控制”</Bold></Italic>时才会生效。<LineBreak /><LineBreak />
+        <Bold>注意：</Bold> 降低刷新率时，您的 Nvidia 3D 眼镜也会在较低的快门频率下工作。对某些人而言，100 Hz 可能会被察觉为屏幕闪烁。
+    </TextBlock>
+
+    <TextBlock x:Key="renderApiToolTip" TextWrapping="Wrap" Width="300">
+        选择游戏所使用的渲染 API，并将该数据保存到修复配置中。<LineBreak /><LineBreak />
+        输入此信息后，当您在<Italic><Bold>“安装”</Bold></Italic>选项卡中点击<Italic><Bold>“安装 3D 封装器”</Bold></Italic>按钮时，可自动安装正确的 3D 封装器。如果游戏使用 DirectX 11，将安装 <Bold>3Dmigoto</Bold>；如果是 DirectX 9，将安装 <Bold>Helixmod</Bold>。<LineBreak /><LineBreak />
+        <Bold>注意：</Bold> 对于那些已经是 3D Vision Ready 且完全不需要修复的游戏，安装原生封装器会变得非常有用。通过使用封装器，您可以解锁快捷键支持（用于在过场动画中快速更改分离度/汇聚），或者用于选择其他的 3D 格式（例如电视和投影仪的并排 Side-By-Side 格式）。
+    </TextBlock>
+
+    <TextBlock x:Key="ProductPageUrlToolTip" TextWrapping="Wrap" Width="300">
+        您可以提供一个包含了游戏信息的在线商店链接。当您在<Italic><Bold>“安装”</Bold></Italic>选项卡中点击<Italic><Bold>“产品页面”</Bold></Italic>按钮时，会打开此链接。如果游戏未在 Steam 商店上架，这是一个很好的替代方案。
+    </TextBlock>
+
+    <TextBlock x:Key="CmFlagToolTip" TextWrapping="Wrap" Width="300">
+       添加兼容性模式标志 (2DDHUDSettings) 的十六进制值。当您在“安装”或“快捷键”选项卡中强制开启 CM 模式时，此值将被设置在 3dmigoto 的 ini 文件中。
+    </TextBlock>
+
+    <TextBlock x:Key="FixArchiveExtractorToolTip" TextWrapping="Wrap" Width="300">
+       修复压缩包在下载后会自动解压。在此选择是使用内置的 SharpCompress 还是使用 7-zip 进行文件解压。
+    </TextBlock>
+
+    <TextBlock x:Key="WebLinkHelixToolTip" TextWrapping="Wrap" Width="300">
+        插入该 3D 修复所出处的 Helix 博客链接 <Bold><Italic>(http://helixmod.blogspot.com/...)</Italic></Bold>。<LineBreak/><LineBreak/>
+        然后点击<Bold><Italic>“Blogger API”</Italic></Bold>按钮，即可自动将修复说明文本、下载链接和其它必要信息插入到修复配置中。<LineBreak/><LineBreak/>
+        如果特定 3D 修复没有对应的 Helix 博客文章，请插入 Geforce 论坛帖子链接替代。然而请注意，在这种情况下，您将无法自动获取说明文本和修复下载链接。<LineBreak/><LineBreak/>
+        此外，您还可以通过在<Bold><Italic>“安装”</Italic></Bold>选项卡中点击<Bold><Italic>“Helixmod 博客”</Italic></Bold>按钮，在 Web 浏览器中打开该声明的链接。
+    </TextBlock>
+
+    <TextBlock x:Key="GameEngineToolTip" TextWrapping="Wrap" Width="300">
+        通过点击<Bold><Italic>“检测引擎”</Italic></Bold>按钮，您可以自动检测个别游戏所使用的引擎。在执行此操作时，系统会搜索 Wikipedia 和 PC Gaming Wiki 网页上的信息。<LineBreak/><LineBreak/>    
+        如果游戏引擎检测失败，您可以点击<Bold><Italic>“Wikipedia”</Italic></Bold>和<Bold><Italic>“PC Gaming Wiki”</Italic></Bold>按钮访问这些网页并手动查找信息。<LineBreak/><LineBreak/>      
+        对于 <Bold>Frostbite 3</Bold> / <Bold>Unity 5</Bold> / <Bold>虚幻引擎 4</Bold> 和 <Bold>Telltale 引擎</Bold> 的游戏，系统提供了通用 3D 修复，可自动添加到修复配置中。<LineBreak/><LineBreak/>  
+        <Bold>注意：</Bold> 为了提高自动检测游戏引擎的成功率，您应该首先输入 Steam App ID。您可以通过点击<Bold><Italic>“游戏标题”</Italic></Bold>旁边的<Bold><Italic>“搜索 Steam 数据库”</Italic></Bold>按钮来完成。
+    </TextBlock>
+
+    <TextBlock x:Key="IconPathToolTip" TextWrapping="Wrap" Width="300">
+        您可以为游戏提供一个可选图标，该图标将显示在<Italic><Bold>“安装”</Bold></Italic>选项卡中。<LineBreak/><LineBreak/>
+        建议的分辨率为 128x128 像素。<LineBreak/><LineBreak/>
+        要移除配置文件夹内的活动图标，请点击<Italic><Bold>“移除图标”</Bold></Italic>，然后再点击<Italic><Bold>“保存”</Bold></Italic>。
+        旧图标的备份将自动在配置文件夹内的一个备份文件夹中被创建。
+    </TextBlock>
+
+    <TextBlock x:Key="IconUrlToolTip" TextWrapping="Wrap" Width="300">
+        如果 3D Fix Manager 无法通过 Windows 注册表找到游戏的本地图标，请提供一个 URL 以自动下载游戏图标。<LineBreak/><LineBreak/>
+        为了使用方便，只需从列表中选择<Italic><Bold>“TheGamesDb 图标”</Bold></Italic>，然后点击<Italic><Bold>“搜索 URL”</Bold></Italic>。<LineBreak/><LineBreak/>
+        如果您想下载一个新图标，但旧图标已经存在，请同时点击上方按钮<Italic><Bold>“移除图标”</Bold></Italic>。请别忘了保存更改。
+    </TextBlock>
+
+    <TextBlock x:Key="Profile2DModeToolTip" TextWrapping="Wrap" Width="300">
+        选择 Nvidia Profile Inspector 的 .nip 文件，以恢复 2D 模式驱动配置为原始状态。<LineBreak/><LineBreak/>
+        当您在 2D 模式下启动游戏或卸载修复时，此配置文件将自动导入 Nvidia Inspector 中。<LineBreak/><LineBreak/>
+        此外，您可以设置是否希望在安装驱动配置文件前接收提示<Italic><Bold>（带对话框提示安装）</Bold></Italic>，或者不接收提示<Italic><Bold>（静默安装）</Bold></Italic>。
+        要使其生效，请在<Italic><Bold>“设置”</Bold></Italic>选项卡中启用<Italic><Bold>“驱动配置文件的安装由修复配置控制”</Bold></Italic>。
+    </TextBlock>
+
+    <TextBlock x:Key="Profile3DModeToolTip" TextWrapping="Wrap" Width="300">
+        选择 Nvidia Profile Inspector 的 .nip 文件，以为 3D 模式自定义一个驱动配置文件。<LineBreak/><LineBreak/>
+        当您在 3D 模式下启动游戏时，此配置文件将自动导入 Nvidia Inspector 中。<LineBreak/><LineBreak/>
+        此外，您可以设置是否希望在安装驱动配置文件前接收提示<Italic><Bold>（带对话框提示安装）</Bold></Italic>，或者不接收提示<Italic><Bold>（静默安装）</Bold></Italic>。
+        要使其生效，请在<Italic><Bold>“设置”</Bold></Italic>选项卡中启用<Italic><Bold>“驱动配置文件的安装由修复配置控制”</Bold></Italic>。
+    </TextBlock>
+
+    <TextBlock x:Key="FixStateToolTip" TextWrapping="Wrap" Width="300">
+        此信息将在安装选项卡中通过一个图标来显示。<LineBreak/><LineBreak/>
+        选择此修复在使用 3D Fix Manager 安装后是否可开箱即用，或者用户是否需要执行一些额外步骤才能完成安装。<LineBreak/><LineBreak/>
+        您可以在右侧字段中提供附加信息。该信息将作为图标的工具提示显示。
+    </TextBlock>
+
+    <TextBlock x:Key="VrCompatibilityToolTip" TextWrapping="Wrap" Width="300">
+        将游戏标记为兼容虚拟现实 (VR) 模式。<LineBreak/><LineBreak/>
+        这允许根据 VR 兼容性过滤游戏列表。如需这样做，请将过滤器设置为<Italic><Bold>“兼容 VR”</Bold></Italic>。
+    </TextBlock>
+
+    <TextBlock x:Key="Uses3DDirectToolTip" TextWrapping="Wrap" Width="300">
+        设置游戏是否使用 NVidia 3D Direct Mode 来生成立体图像。
+    </TextBlock>
+
+    <TextBlock x:Key="VrRequiresSwCursorToolTip" TextWrapping="Wrap" Width="300">
+        设置游戏是否使用软件鼠标指针。（仅适用于 DirectX 11 游戏）<LineBreak/><LineBreak/>
+        如果在 VR 模式下游玩时看不到鼠标光标，则应启用此选项。
+    </TextBlock>
+
+    <TextBlock x:Key="RequiresSwCursorToolTip" TextWrapping="Wrap" Width="300">
+        设置游戏是否使用软件鼠标指针。（仅适用于 DirectX 11 游戏）<LineBreak/><LineBreak/>
+        如果在使用左右格式 (SBS) 或上下格式 (TaB) 时，发现仅在一只眼睛的画面中能看到鼠标光标，则应启用此选项。<LineBreak/><LineBreak/>
+        在 HelixVision 的 VR 模式下，如果您完全无法在虚拟屏幕上看到鼠标光标，也应启用软件鼠标指针。
+    </TextBlock>
+
+    <TextBlock x:Key="MultiplayerOnlineWarningToolTip" TextWrapping="Wrap" Width="300">
+        设置是否在为在线游戏安装驱动修改之前显示警告。<LineBreak/><LineBreak/>
+        该警告用于提醒：多人游戏通常使用反作弊机制，此机制可能禁止对显卡驱动进行任何修改。
+    </TextBlock>
+
+    <TextBlock x:Key="OptimizedConvergenceValueToolTip" TextWrapping="Wrap" Width="300">
+        设置在游戏启动时应用到驱动配置上的汇聚值。<LineBreak/><LineBreak/>
+        该值经过优化，能在虚拟屏幕上达到最佳的 3D 效果。
+    </TextBlock>
+
+    <TextBlock x:Key="MaxConvergenceValueToolTip" TextWrapping="Wrap" Width="300">
+        设置在 VR 中游玩时依然合适的最高汇聚值。
+    </TextBlock>
+
+    <TextBlock x:Key="SteamAppIDToolTip" TextWrapping="Wrap" Width="300">
+        Steam App ID 对于启动 Steam 游戏和访问 Steam 商店是必需的。
+    </TextBlock>
+
+    <TextBlock x:Key="EpicAppIDToolTip" TextWrapping="Wrap" Width="300">
+        Epic App ID 对于启动 Epic Store 的游戏是必需的。
+    </TextBlock>
+
+    <TextBlock x:Key="GameLauncherExeToolTip" TextWrapping="Wrap" Width="300">
+        用于启动游戏的可执行文件的名称。<LineBreak/><LineBreak/>
+        <Bold>重要提示：</Bold> 此字段必须填写，否则无法在硬盘上找到该游戏。<LineBreak/><LineBreak/>
+        如果可执行文件位于游戏的子目录中，您还必须通过填写上面的单独字段<Italic><Bold>“相对安装路径”</Bold></Italic>，来提供可执行文件的相对路径。
+    </TextBlock>
+
+    <TextBlock x:Key="ToolExeToolTip" TextWrapping="Wrap" Width="300">
+        填写位于游戏目录下的 exe 文件名称，或填写一个绝对路径，用于在启动游戏之前先运行某个特定程序。此功能在诸如 Far Cry 2, F.E.A.R. 和 INSIDE 等游戏的配置中被使用，因为它们需要先调用另一个 exe 文件。<LineBreak/><LineBreak/>
+        此外，您可以设置是否将游戏 exe 作为一个启动参数传递给该工具，以及游戏启动是否需等待工具退出后再继续。您还可通过复制并重命名游戏 exe，来设置是否创建一个新的工具 exe。
+    </TextBlock>
+
+    <TextBlock x:Key="GameLauncherOptionsToolTip" TextWrapping="Wrap" Width="300">
+        如果需要，可以在此为游戏启动器 Exe 设置参数（如需示例，请查看游戏<Italic><Bold>“Superhot”</Bold></Italic>的修复配置）。<LineBreak/><LineBreak/>
+        此外，您还可以决定是否以管理员权限启动游戏（例如游戏<Italic><Bold>“Doom”</Bold></Italic>需要这样做），或者选择游戏的启动方式（直接通过游戏 exe 启动，还是通过 Steam App ID 间接启动）。
+    </TextBlock>
+
+    <TextBlock x:Key="ModifyExeSearchStringToolTip" TextWrapping="Wrap" Width="300">
+        通过使用此选项，您可以修改 Exe 文件的内容，以使其在立体 3D 模式下正确工作。到目前为止，只有一些“乐高 (LEGO)”游戏需要这样做。<LineBreak/><LineBreak/>
+        为此，系统会将 exe 文件作为二进制数据读取，并搜索您在右侧字段中定义的字符串。然后找到的字符串将被替换为您在提供的字段中设置的另一个字符串。<LineBreak/><LineBreak/>
+        出于安全原因，在保存修改后的文件之前，原始文件会在游戏目录中进行备份。
+    </TextBlock>
+
+    <TextBlock x:Key="FixDescriptionToolTip" TextWrapping="Wrap" Width="300">
+        提供关于该 3D Vision 修复的描述。<LineBreak/><LineBreak/>
+        您可以从 Helixmod 网站上复制该文本，或自己编写一段描述。
+    </TextBlock>
+
+    
+    <!-- Hotkeys Tab ToolTips -->
+    <TextBlock x:Key="HuntingModeToolTip" TextWrapping="Wrap" Width="300">
+        狩猎模式主要面向 Shader 开发者。它使开发者能够在立体 3D 模式下查找损坏的着色器并进行修复。<LineBreak/><LineBreak/>
+        对普通最终用户而言，狩猎模式的用处在于能在游戏中显示一层当前 3D 深度和汇聚值的覆盖层信息。通过该信息，用户可以微调 3D 快捷键。<LineBreak/><LineBreak/>
+        <Bold>关：</Bold> 禁用狩猎模式及立体 3D 覆盖层。<LineBreak/><LineBreak/>
+        <Bold>开：</Bold> 启用狩猎模式及立体 3D 覆盖层。<LineBreak/><LineBreak/>     
+        <Bold>软禁用：</Bold> 狩猎模式及立体 3D 覆盖层未被完全禁用。在游戏中按下“0”键（默认按键）即可显示覆盖层。
+    </TextBlock>
+
+    <TextBlock x:Key="KeyTypeMigotoToolTip" TextWrapping="Wrap" Width="300">
+        选择一种快捷键类型。所有类型的共同点是在按键时会启用一个 3D 预设。预设规定了哪些 3D 设置将被覆盖（例如，3D 分离度、汇聚或 Shader 常量）。<LineBreak/><LineBreak/>
+        具体的快捷键类型控制了在释放按键或多次按键时所发生的事情。根据类型的不同，可以激活不同的 3D 预设，或者恢复到原始的 3D 设置。<LineBreak/><LineBreak/>  
+        <Bold>循环 (Cycle)：</Bold> 允许您添加任意数量的 3D 预设，并且在每次击键后依次激活下一个预设。当到达最后一个预设时，下一次击键会重新触发第一个预设。<LineBreak/><LineBreak/>
+        <Bold>按住 (Hold)：</Bold> 仅允许添加一个 3D 预设，并且只要按住该键即保持激活状态。松开按键后，该 3D 预设被禁用并恢复为原始 3D 设置。<LineBreak/><LineBreak/>
+        <Bold>切换 (Toggle)：</Bold> 仅允许添加一个 3D 预设，并在按下该键时启用它。再次按下该键后，该 3D 预设被禁用并恢复为原始 3D 设置。
+    </TextBlock>
+
+    <TextBlock x:Key="KeyTypeHelixToolTip" TextWrapping="Wrap" Width="300">
+        选择一种快捷键类型。所有类型的共同点是在按键时会启用一个 3D 预设。预设规定了哪些 3D 设置将被覆盖（例如，3D 分离度、汇聚或 Shader 常量）。<LineBreak/><LineBreak/>
+        具体的快捷键类型控制了在释放按键或多次按键时所发生的事情。根据类型的不同，可以激活不同的 3D 预设，或者恢复到原始的 3D 设置。<LineBreak/><LineBreak/>  
+        <Bold>循环 (Cycle)：</Bold> 允许您添加任意数量的 3D 预设，并且在每次击键后依次激活下一个预设。当到达最后一个预设时，下一次击键会重新触发第一个预设。<LineBreak/><LineBreak/>
+        <Bold>按住 (Hold)：</Bold> 允许您最多添加两个 3D 预设，并在按住该键时激活第一个。释放该键后，第二个预设会被启用；如果第二个预设不存在，则恢复为原始 3D 设置。
+    </TextBlock>
+
+    <TextBlock x:Key="KeyTypeOpenGlToolTip" TextWrapping="Wrap" Width="300">
+        选择一种快捷键类型。所有类型的共同点是在按键时会启用一个 3D 预设。预设规定了哪些 3D 设置将被覆盖（例如，3D 分离度、汇聚或 Shader 常量）。<LineBreak/><LineBreak/>
+        具体的快捷键类型控制了在释放按键或多次按键时所发生的事情。根据类型的不同，可以激活不同的 3D 预设，或者恢复到原始的 3D 设置。<LineBreak/><LineBreak/>  
+        <Bold>按住 (Hold)：</Bold> 仅允许添加一个 3D 预设，并且只要按住该键即保持激活状态。松开按键后，该 3D 预设被禁用并恢复为原始 3D 设置。<LineBreak/><LineBreak/>
+        <Bold>切换 (Toggle)：</Bold> 仅允许添加一个 3D 预设，并在按下该键时启用它。再次按下该键后，该 3D 预设被禁用并恢复为原始 3D 设置。
+    </TextBlock>
+
+    <TextBlock x:Key="KeyTypeOpenGlNewVersionToolTip" TextWrapping="Wrap" Width="300">
+        选择一种快捷键类型。所有类型的共同点是在按键时会启用一个 3D 预设。预设规定了哪些 3D 设置将被覆盖（例如，3D 分离度、汇聚或 Shader 常量）。<LineBreak/><LineBreak/>
+        具体的快捷键类型控制了在释放按键或多次按键时所发生的事情。根据类型的不同，可以激活不同的 3D 预设，或者恢复到原始的 3D 设置。<LineBreak/><LineBreak/>  
+        <Bold>按住 (Hold)：</Bold> 仅允许添加一个 3D 预设，并且只要按住该键即保持激活状态。松开按键后，该 3D 预设被禁用并恢复为原始 3D 设置。<LineBreak/><LineBreak/>
+        <Bold>切换 (Toggle)：</Bold> 仅允许添加一个 3D 预设，并在按下该键时启用它。再次按下该键后，该 3D 预设被禁用并恢复为原始 3D 设置。<LineBreak/><LineBreak/>
+        <Bold>单次 (One-Time)：</Bold> 仅允许添加一个 3D 预设，并在按下该键时启用它。与其他快捷键类型不同的是，使用此模式将无法恢复到之前的 3D 设置。
+    </TextBlock>
+
+    <TextBlock x:Key="DefaultPresetToolTip" TextWrapping="Wrap" Width="300">
+        启用此选项后，您可以定义一个启动游戏时即激活的默认预设。
+    </TextBlock>
+
+    <TextBlock x:Key="cbDefaultPresetToolTip" TextWrapping="Wrap" Width="300">
+        这是在启动游戏时默认激活的预设。
+    </TextBlock>
+
+    <TextBlock x:Key="DelayToolTip" TextWrapping="Wrap" Width="300">
+        启用此选项后，您可以定义一个持续按压时间：必须按住某键足够长的时间，相应的 3D 预设才会激活。
+    </TextBlock>
+
+    <TextBlock x:Key="DelayMsToolTip" TextWrapping="Wrap" Width="300">
+        以 [毫秒, ms] 为单位的时间：必须按住该键这么长的时间，3D 预设才会激活。
+    </TextBlock>
+
+    <TextBlock x:Key="ReleaseDelayToolTip" TextWrapping="Wrap" Width="300">
+        启用此选项后，您可以定义释放按键后经过多长时间，才恢复到按键之前有效的原始立体 3D 设置。
+    </TextBlock>
+
+    <TextBlock x:Key="ReleaseDelayMsToolTip" TextWrapping="Wrap" Width="300">
+        以 [毫秒, ms] 为单位的时间：在释放按键后需要等待多长时间以恢复原始立体 3D 设置。
+    </TextBlock>
+
+    <TextBlock x:Key="TransitionToolTip" TextWrapping="Wrap" Width="300">
+        启用此选项后，3D 预设之间的切换将采用柔和的淡入淡出过渡效果。过渡的类型和持续时间可由用户定义。
+    </TextBlock>
+
+    <TextBlock x:Key="TransitionMsToolTip" TextWrapping="Wrap" Width="300">
+        以 [毫秒, ms] 为单位的时间：不同 3D 预设间发生过渡所需的时间。
+    </TextBlock>
+
+    <TextBlock x:Key="ReleaseTransitionToolTip" TextWrapping="Wrap" Width="300">
+        启用此选项后，原始立体 3D 设置将通过柔和的过渡恢复。过渡的类型和持续时间可由用户定义。
+    </TextBlock>
+
+    <TextBlock x:Key="ReleaseTransitionMsToolTip" TextWrapping="Wrap" Width="300">
+        以 [毫秒, ms] 为单位的时间：释放按键后通过过渡效果恢复原始立体 3D 设置所需的时间。
+    </TextBlock>
+
+    <TextBlock x:Key="TransitionTypeToolTip" TextWrapping="Wrap" Width="300">
+        用于不同 3D 预设间交叉淡入淡出的过渡效果类型。
+    </TextBlock>
+
+    <TextBlock x:Key="StereoProfileToolTip" TextWrapping="Wrap" Width="300">
+        需要此设置来启用驱动中大量与立体相关的代码，并允许保存汇聚设置。<LineBreak/><LineBreak/>
+        如果您在自定义配置文件，应始终将此项设为<Italic><Bold>“是”</Bold></Italic>。
+    </TextBlock>
+
+    <TextBlock x:Key="StereoFlagsDX10ToolTip" TextWrapping="Wrap" Width="300">
+        此设置启用了立体计算着色器 (Compute Shaders)，这在修复许多 DX11 游戏中“单眼无渲染”类问题时是必需的。<LineBreak/><LineBreak/>
+        将此选项设置为 0x00004000 即可解决此问题。
+    </TextBlock>
+
+    <TextBlock x:Key="StereoConvergenceToolTip" TextWrapping="Wrap" Width="300">
+        这会设置该配置文件中的默认汇聚值。<LineBreak/><LineBreak/>
+        请注意，3DMigoto 会乐意覆盖驱动中的默认值，但只有在它有其他理由需要更新配置时（例如对另一项设置的更改，向 Comments 设置中添加版本标签就是强制更新的一种方式），才会覆盖用户的自定义汇聚值。
+    </TextBlock>
+
+    <TextBlock x:Key="CommentsToolTip" TextWrapping="Wrap" Width="300">
+        这会更改驱动在屏幕上显示的绿色文本，是用于向用户展示提示信息或留名的好地方。
+    </TextBlock>
+
+    <TextBlock x:Key="StereoMemoEnabledToolTip" TextWrapping="Wrap" Width="300">
+        如果您添加了一些评论，您可能会希望通过将此选项设为<Italic><Bold>“是”</Bold></Italic>，在下次运行游戏时强制显示该绿色文本。<LineBreak/><LineBreak/>
+        请注意，如同汇聚值一样，3DMigoto 仅在其他内容也被更新时（例如 Comments）才会覆盖此处用户的设置。因此这通常只会在用户安装修复后第一次运行游戏时显示（请务必启用 StereoProfile）。
+    </TextBlock>
+
+    <TextBlock x:Key="2DDHUDSettingsToolTip" TextWrapping="Wrap" Width="300">
+        如果驱动配置文件中尚未提供，此设置将强制游戏支持兼容性模式。<LineBreak/><LineBreak/>
+        十六进制值控制兼容模式的设置——整体的 3D 强度、将 HUD 固定在屏幕深度的启发算法、以及评级。<LineBreak/><LineBreak/>
+        您应该将此选项设置为 0x10000002 或 0x10000102。当然您也可以自由尝试其他数值。
+    </TextBlock>
+
+    <TextBlock x:Key="2DDConvergenceToolTip" TextWrapping="Wrap" Width="300">
+        这会在兼容模式下设置默认的汇聚值。
+    </TextBlock>
+
+    <TextBlock x:Key="Disable2DDToolTip" TextWrapping="Wrap" Width="300">
+        禁用兼容模式，以确保用户看到的是原汁原味的真实 3D 画面。<LineBreak/><LineBreak/>
+        像汇聚值一样，3DMigoto 会尊重用户在此处的自定义设置。
+    </TextBlock>
+
+    <TextBlock x:Key="TwoDDNotesToolTip"  TextWrapping="Wrap" Width="300">
+        在兼容模式的绿色文本中留下一条提醒，告知他们现在看到的并不是真实 3D (Real Deal)。
+    </TextBlock>
+
+    <TextBlock x:Key="EnableStereoOverlayToolTip" TextWrapping="Wrap" Width="300">
+        启用一个游戏内覆盖层以显示当前的汇聚 / 分离度数值。这也同时启用了用于着色器修复的狩猎模式。<LineBreak/><LineBreak/>
+        请别忘了在完成快捷键的编辑后取消勾选此选项，以获得更好的游戏性能。
+    </TextBlock>
+
+    <TextBlock x:Key="EnableSoftwareMouseToolTip" TextWrapping="Wrap" Width="300">
+        通过软件来渲染鼠标指针；当您希望调整鼠标的立体深度，或需要结合其它替代 3D 输出格式（如左右格式）使用时，应当勾选此项。
+    </TextBlock>
+
+    
+    <!-- General Settings Tab ToolTips -->
+    <TextBlock x:Key="CheckForUpdatesToolTip" TextWrapping="Wrap" Width="300">
+        启动应用程序时自动检查程序本身或修复文件的更新。
+    </TextBlock>
+
+    <TextBlock x:Key="CheckForDriverUpdatesToolTip" TextWrapping="Wrap" Width="300">
+        启动应用程序时自动检查 Geforce 驱动的更新。
+    </TextBlock>
+
+    <TextBlock x:Key="UseHwAccelerationToolTip" TextWrapping="Wrap" Width="300">
+        设置是否使用 GPU 渲染本程序的图形用户界面 (GUI)。<LineBreak/><LineBreak/>
+        启用硬件加速可提高应用程序的响应速度。<LineBreak/><LineBreak/>
+        如果您遇到程序意外崩溃的问题，请禁用此选项。
+    </TextBlock>
+
+    <TextBlock x:Key="AllowChangesToGameConfigToolTip" TextWrapping="Wrap" Width="300">
+        此项允许 3D Fix Manager 在启动游戏时自动优化游戏的图形设置 / 配置文件。<LineBreak/><LineBreak/>
+        这对于确保 3D 修复和立体 3D 模式能够正常工作并正确渲染是必不可少的。<LineBreak/><LineBreak/>
+        <Bold>注意：</Bold> 除非您更倾向于手动配置游戏，否则才应当关闭此选项。
+    </TextBlock>
+
+    <TextBlock x:Key="FullscreenOptimizationsToolTip" TextWrapping="Wrap" Width="300">
+       “全屏优化”是 Windows 10 引入的一项功能，并自 Windows 更新 1803 (2018 年 4 月更新) 起默认启用。<LineBreak/><LineBreak/>
+       此功能的目的是提供一种无边框全屏模式，同时提供像独占全屏模式那样的性能优势。<LineBreak/><LineBreak/>
+       <Bold>重要：</Bold> 如果您在游戏时遇到了 3D 无法工作、SLI 缩放不正确或画面卡顿等问题，您应该禁用全屏优化。<LineBreak/><LineBreak/>
+       您可以选择全局禁用全屏优化，或仅针对特定游戏禁用。如果选择后者，您可以在单独的修复配置中控制它。
+    </TextBlock>
+
+    <TextBlock x:Key="FullscreenOptimizationsProfileToolTip" TextWrapping="Wrap" Width="300">
+       “全屏优化”是 Windows 10 引入的一项功能，并自 Windows 更新 1803 (2018 年 4 月更新) 起默认启用。<LineBreak/><LineBreak/>
+       此功能的目的是提供一种无边框全屏模式，同时提供像独占全屏模式那样的性能优势。<LineBreak/><LineBreak/>
+       <Bold>重要：</Bold> 如果您在游戏时遇到了 3D 无法工作、SLI 缩放不正确或画面卡顿等问题，您应该禁用全屏优化。<LineBreak/><LineBreak/>
+       <Bold>注意：</Bold> 仅当您之前在<Bold><Italic>“应用程序设置”</Italic></Bold>选项卡中将<Bold><Italic>“全屏优化”</Italic></Bold>设置为<Italic>“由修复配置控制”</Italic>时，该设置才会处于激活状态。
+    </TextBlock>
+
+    <TextBlock x:Key="DisableFixIn2dModeToolTip" TextWrapping="Wrap" Width="300">
+       在 2D 模式下启动游戏时自动禁用 3D 修复。<LineBreak/><LineBreak/>
+       如果您想在 2D 模式下使用 3dmigoto 作为 Mod 修改工具，请将此选项设置为<Bold><Italic>“否”</Italic></Bold>。<LineBreak/><LineBreak/>
+       <Bold>注意：</Bold> 仅当您之前在<Italic><Bold>“应用程序设置”</Bold></Italic>选项卡中将<Italic><Bold>“在 2D 模式下禁用 3D 修复”</Bold></Italic>设置为<Italic><Bold>“由修复配置控制”</Bold></Italic>时，该设置才会激活。
+    </TextBlock>
+
+    <TextBlock x:Key="DisableFixesIn2dModeToolTip" TextWrapping="Wrap" Width="300">
+       在 2D 模式下启动游戏时自动禁用所有 3D 修复。<LineBreak/><LineBreak/>
+       如果您想在 2D 模式下将 3dmigoto 作为 Mod 修改工具使用，请将此选项设置为<Bold><Italic>“否”</Italic></Bold>。
+    </TextBlock>
+
+    <TextBlock x:Key="EnableSteamOverlayToolTip" TextWrapping="Wrap" Width="300">
+        如果您在启动游戏时遇到崩溃问题，请禁用 Steam 覆盖层 (Overlay)。
+    </TextBlock>
+    
+    <TextBlock x:Key="SendDataToolTip" TextWrapping="Wrap" Width="300">
+        当用户在“编辑配置”选项卡中自定义修复配置并点击<Italic><Bold>“保存”</Bold></Italic>按钮时，检测到的修改将会被发送到 MySQL 服务器。<LineBreak/><LineBreak/>
+        此功能有助于 3D Fix Manager 的作者为修复配置添加缺失的数据或进行错误修正。
+    </TextBlock>
+    
+    <TextBlock x:Key="AutoUpdate3dmigotoToolTip" TextWrapping="Wrap" Width="300">
+        只要 3D Fix Manager 一经启动，就会自动为所有已安装的 3D 修复更新 3dmigoto。
+         <Bold>注意：</Bold> 3dmigoto 是一个软件封装器，这意味着它能够使 Shader 开发者修复游戏中的立体效果。推荐使用该封装器的最新版本。
+    </TextBlock>
+    
+    <TextBlock x:Key="ReinstallFixFromCacheToolTip" TextWrapping="Wrap" Width="300">
+        在不重新下载的情况下重新安装 3D 修复。为了实现这一点，已下载的文件将保存在 3D Fix Manager 目录中，用于重新安装 3D 修复。<LineBreak/><LineBreak/>
+        如果您想通过删除已下载的文件来释放硬盘空间，只需转至<Italic><Bold>“安装”</Bold></Italic>选项卡并点击<Italic><Bold>“清除缓存”</Bold></Italic>。
+    </TextBlock>
+    
+    <TextBlock x:Key="ResetAllIconsToolTip" TextWrapping="Wrap" Width="300">
+        启用此选项可从 TheGamesDB 或 Steam 数据库重新下载所有图标。<LineBreak/><LineBreak/>
+        旧图标不会丢失，它们会被保存在各自配置文件夹内的备份文件夹中。
+    </TextBlock>
+
+    <TextBlock x:Key="DownloadScreenshotsToolTip" TextWrapping="Wrap" Width="300">
+        下载并显示包含在 3D 修复说明文本中的立体 3D 屏幕截图。<LineBreak/><LineBreak/>
+        如果在下载图像时用户界面 (GUI) 出现冻结，请禁用此选项。
+    </TextBlock>
+
+    <TextBlock x:Key="ClearAllDownladCacheToolTip" TextWrapping="Wrap" Width="300">
+        删除所有临时缓存在 3D Fix Manager 目录下的已下载 3D 修复文件。<LineBreak/><LineBreak/>
+       <Bold>注意：</Bold> 此功能不会删除任何已安装的 3D 修复文件，它只是释放应用程序目录中的一些磁盘空间。
+    </TextBlock>
+
+    <TextBlock x:Key="PreferIconDownloadToolTip" TextWrapping="Wrap" Width="300">
+        如果您希望始终从互联网下载图标，即使已经通过 Windows 注册表找到了本地图标，也请启用此选项。
+    </TextBlock>
+    
+    <TextBlock x:Key="UpdateAllWrappersToolTip" TextWrapping="Wrap" Width="300">
+        将所有已安装修复中的 3dmigoto 更新至最新版本。<LineBreak/><LineBreak/>
+        新版本的 3dmigoto 可能具有更好的性能 / 稳定性，并解锁支持左右格式 (SideBySide) 等新功能。
+    </TextBlock>
+
+    <TextBlock x:Key="EnableCachedPathsToolTip" TextWrapping="Wrap" Width="300">
+        启用此功能后，所有游戏路径将被缓存到独立修复配置的文件中。因此，如果计算机上安装了大量游戏和程序，应用程序的启动速度将显著提高。<LineBreak/><LineBreak/>
+        建议保持禁用此功能，除非应用程序在您的机器上启动耗时太长。<LineBreak/><LineBreak/>
+        <Bold>注意：</Bold> 请记住，在启动应用程序时，不再主动通过 Windows 注册表或搜索路径来查找安装的游戏，所有信息都将从缓存中提取。
+        这样做的副作用是新安装的游戏将不再被自动检测到。遇到这种情况，请刷新游戏列表（点击刷新按钮）或点击下方的<Bold><Italic>“搜索游戏”</Italic></Bold>按钮，缓存即会被自动重建。
+    </TextBlock>
+
+    <TextBlock x:Key="EnableRegistrySearchToolTip" TextWrapping="Wrap" Width="300">
+        通过在 Windows 注册表的特定位置中搜索与各自修复配置同名的注册表键，来检测已安装的游戏。<LineBreak/><LineBreak/>
+        这些注册表键包含有关游戏安装位置的信息。
+    </TextBlock>
+    
+    <TextBlock x:Key="EnableSearchPathsToolTip" TextWrapping="Wrap" Width="300">
+        通过在硬盘上查找与各个修复配置名称相同的文件夹来检测已安装的游戏。<LineBreak/><LineBreak/>
+        您可以通过定义搜索路径来指定要搜索的目录（见下文）。如果达到最大搜索深度，搜索会自动取消。<LineBreak/><LineBreak/>
+        为了成功检测到已安装的游戏，还必须在文件夹中找到对应的游戏 exe。这可以避免将包含空游戏文件夹的游戏错误地标记为已安装。
+    </TextBlock>
+    
+    <TextBlock x:Key="PrioritizeSearchPathsToolTip" TextWrapping="Wrap" Width="300">
+        当游戏同时通过搜索路径和 Windows 注册表找到时，系统将优先应用通过搜索路径找到的安装位置。
+    </TextBlock>
+
+    <TextBlock x:Key="PathsToolTip" TextWrapping="Wrap" Width="300">
+      系统将通过递归遍历这些路径以寻找游戏。
+    </TextBlock>
+
+    <TextBlock x:Key="SearchGamesToolTip" TextWrapping="Wrap" Width="300">
+       触发以寻找已安装游戏的搜索动作，并更新列表。
+    </TextBlock>
+
+    <TextBlock x:Key="SearchDepthToolTip" TextWrapping="Wrap" Width="300">
+       设置应用程序为了寻找游戏而遍历子目录的最大深度。
+    </TextBlock>
+    
+    <TextBlock x:Key="StartRTSS_SettingToolTip" TextWrapping="Wrap" Width="300">
+       当用户启动游戏时，RivaTuner Statistics Server (RTSS) 将根据各个修复配置文件中的设置自动打开或关闭。
+    </TextBlock>
+    
+    <TextBlock x:Key="InterruptGameLaunchToolTip" TextWrapping="Wrap" Width="300">
+        赋予用户在游戏启动前设置 RTSS 的机会。请确保帧率限制器设定为 60 fps，以实现流畅的游戏体验并减少输入延迟。
+    </TextBlock>
+    
+    <TextBlock x:Key="CloseRivaTunerIn2DToolTip" TextWrapping="Wrap" Width="300">
+       在 2D 模式下启动游戏时，始终关闭 RTSS，无论修复配置文件中是如何定义的。
+    </TextBlock>
+    
+    <TextBlock x:Key="NeverCloseRivaTunerIn2DToolTip" TextWrapping="Wrap" Width="300">
+        在 2D 模式下启动游戏时，绝不关闭正在运行的 RTSS 实例，无论修复配置文件中是如何定义的。
+    </TextBlock>
+    
+    <TextBlock x:Key="CloseRtssOnAppCloseToolTip" TextWrapping="Wrap" Width="300">
+        在用户退出 3D Fix Manager 时，自动关闭正在运行的 RTSS 实例。
+    </TextBlock>
+    
+    <TextBlock x:Key="StartGamesByGameExeToolTip" TextWrapping="Wrap" Width="300">
+        全局设置是否直接使用游戏 exe 启动游戏，而不是通过 Steam 客户端。<LineBreak/><LineBreak/>
+        如果修复配置中没有定义游戏启动器 Exe，并且检测到 Steam，游戏依然会通过 Steam 启动。
+    </TextBlock>
+    
+    <TextBlock x:Key="StartGamesBySteamAppIdToolTip" TextWrapping="Wrap" Width="300">
+        全局设置是否通过调用 Steam App ID 并借助 Steam 客户端来启动游戏。<LineBreak/><LineBreak/>
+        如果游戏未在 Steam 上安装，或未检测到 Steam 本身，游戏将改由“游戏启动器 Exe”来启动。
+    </TextBlock>
+    
+    <TextBlock x:Key="StartGamesByFixProfileToolTip" TextWrapping="Wrap" Width="300">
+        在此设置是否应由修复配置单独控制游戏的启动方式。这是决定游戏是直接调用游戏 exe 还是间接调用 Steam 客户端启动的推荐选项。<LineBreak/><LineBreak/>
+        仅当您想绕过游戏启动器窗口时，Steam 游戏才应通过直接调用游戏 exe 的方式来启动。您可以通过编辑各自的修复配置来控制此行为。
+    </TextBlock>
+    
+    <TextBlock x:Key="NeverInstallProfilesToolTip" TextWrapping="Wrap" Width="300">
+       全局禁用所有游戏的驱动配置文件安装。
+    </TextBlock>
+    
+    <TextBlock x:Key="ProfileInstallByFixProfileToolTip" TextWrapping="Wrap" Width="300">
+        启用此选项后，用户可以在单个修复配置中控制是否要安装驱动配置文件。
+    </TextBlock>
+
+    <TextBlock x:Key="InstallProfilesSilentlyToolTip" TextWrapping="Wrap" Width="300">
+        通过启用此选项，通常允许 3D Fix Manager 静默安装驱动配置文件而不显示警告对话框。
+    </TextBlock>
+
+    <TextBlock x:Key="GlobalStereoRefreshRateToolTip" TextWrapping="Wrap" Width="300">
+        通过启用此选项，立体 3D 刷新率和 Nvidia 3D 眼镜的快门频率将保持不变，并由 Nvidia 驱动中的设置控制。
+    </TextBlock>
+
+    <TextBlock x:Key="ProfileStereoRefreshRateToolTip" TextWrapping="Wrap" Width="300">
+        通过启用此选项，您可以针对每个游戏单独控制立体 3D 刷新率和 Nvidia 3D 眼镜的快门频率。
+    </TextBlock>
+
+
+    <!-- Refresh rates and resolution ToolTips -->
+    <TextBlock x:Key="EnableUpscalingToolTip" TextWrapping="Wrap" Width="300">
+        如果您想使用低于显示器原生分辨率的配置进行游戏，画面缩放 (Upscaling) 就会非常有用。<LineBreak/><LineBreak/>           
+        此功能可将画面上采样至您的原生分辨率，以获得更清晰的画质——对于 4K 3D 电视或用于 DSR 功能时尤其有用。<LineBreak/><LineBreak/>   
+        请考虑到这仍然是一项实验性功能，并且仅适用于少数几款游戏（例如《巫师 3》）。如果鼠标指针无法正常工作，请将缩放设置为<Italic><Bold>“强制全屏”</Bold></Italic>或启用“软件鼠标指针”。<LineBreak/><LineBreak/>
+        <Bold>普通全屏：</Bold> 启用缩放并允许游戏自行禁用或启用全屏模式。<LineBreak/><LineBreak/>
+        <Bold>强制全屏：</Bold> 启用缩放并始终强制全屏。如果遇到鼠标指针问题，请尝试此选项。
+    </TextBlock>
+
+    <TextBlock x:Key="UpscalingModeToolTip" TextWrapping="Wrap" Width="300">
+         <Bold>0：</Bold> 3Dmigoto 创建一个纹理，并将其作为后台缓冲推送给游戏。似乎仅对少数游戏有效，但整体运行起来似乎更流畅些。<LineBreak/><LineBreak/>
+         <Bold>1：</Bold> 3Dmigoto 创建第二个交换链 (Swap chain)，并强制游戏使用它。似乎对大多数游戏有效。
+    </TextBlock>
+
+    <TextBlock x:Key="UpscalingScreenToolTip" TextWrapping="Wrap" Width="300">        
+        如果开启了画面缩放，您必须指定游戏要被缩放至的目标分辨率。<LineBreak/><LineBreak/>
+        为了达到最佳视觉效果，请使用您的电视或显示器的原生分辨率。
+    </TextBlock>
+
+    <TextBlock x:Key="FilterRefreshRatesToolTip" TextWrapping="Wrap" Width="300">
+        将可用的视频模式过滤为那些提供特定刷新率的模式。有些游戏不显式设置刷新率，而是使用视频模式。<LineBreak/><LineBreak/>
+        如果设置<Italic><Bold>“覆盖刷新率”</Bold></Italic>不起作用，请使用此选项。
+    </TextBlock>
+
+    <TextBlock x:Key="ForceFullscreenToolTip" TextWrapping="Wrap" Width="300">
+        <Bold>1：</Bold> 强制创建全屏设备及交换链 (Swap chains)。<LineBreak/><LineBreak/>
+        <Bold>2：</Bold> 也会禁用 SetWindowPos 函数，这可能对部分游戏有帮助。
+    </TextBlock>
+
+    <TextBlock x:Key="ToggleFullscreenToolTip" TextWrapping="Wrap" Width="300">
+        如果要在不崩溃的情况下切出 Unity 游戏：<LineBreak/><LineBreak/>
+        启用此选项后，请依次按 F7，Alt+Enter，Alt+Tab。
+    </TextBlock>
+
+    <TextBlock x:Key="ForceFullscreenOnKeyPressToolTip" TextWrapping="Wrap" Width="300">
+        这试图在按键按下时强制开启独占全屏，在<Italic><Bold>游戏启动时强制全屏</Bold></Italic>功能无效或产生不良副作用的游戏中，此选项可能会有所帮助。
+    </TextBlock>
+
+    <!-- Nvidia 3D Settings Tab ToolTips -->
+    <TextBlock x:Key="EnableNvidia3DToolTip" TextWrapping="Wrap" Width="300">
+        手动启用 / 禁用<Bold> Nvidia 立体 3D</Bold>。<LineBreak/><LineBreak/>
+        此功能与 Nvidia 控制面板中<Italic><Bold>“设置立体 3D (Set up stereoscopic 3D)”</Bold></Italic>下的选项作用相同。
+    </TextBlock>
+     
+    <TextBlock x:Key="Disable3dOnClosingToolTip" TextWrapping="Wrap" Width="300">
+         在关闭 3D Fix Manager 时禁用 Nvidia 立体 3D。
+    </TextBlock>
+
+    <TextBlock x:Key="Disable3dOnGameClosingToolTip" TextWrapping="Wrap" Width="300">
+        在关闭正在运行的游戏时禁用 Nvidia 立体 3D。
+    </TextBlock>
+
+    <TextBlock x:Key="SetStereoTypeTo3DVisionToolTip" TextWrapping="Wrap" Width="300">
+        在启用 Nvidia 立体 3D 或在 3D 模式下启动游戏时，自动将 3D 输出模式设置为 3D Vision / 3DTV Play，而不是 3D Vision Discover（红蓝 3D）。
+    </TextBlock>
+    
+    <TextBlock x:Key="StereoEnabledOnGameLaunchToolTip" TextWrapping="Wrap" Width="300">
+        设置当启用 Nvidia 立体 3D 后，游戏是否自动以 3D 模式启动。否则，您必须按下 CTRL + T 手动开启。<LineBreak/><LineBreak/>
+        从技术上讲，此选项将 Windows 注册表项<Italic><Bold>“StereoDefaultOn”</Bold></Italic>设置为 0 或 1。
+    </TextBlock>
+    
+    <TextBlock x:Key="StereoWindowedModeEnabledToolTip" TextWrapping="Wrap" Width="300">
+        设置 3D Vision 是否能为窗口化应用程序激活 3D 模式。<LineBreak/><LineBreak/>
+        从技术上讲，此选项将 Windows 注册表项<Italic><Bold>“EnableWindowedMode”</Bold></Italic>设置为 0 或 5。
+    </TextBlock>
+
+    <TextBlock x:Key="Nvidia3dDriverOverlayToolTip" TextWrapping="Wrap" Width="300">
+        通过此选项，您可以完全关闭在游玩立体 3D 模式时通常会处于激活状态的覆盖层。<LineBreak/><LineBreak/>
+        通过禁用覆盖层，3D 深度图形指示条以及包含绿色文本的信息框将不再显示在游戏中。<LineBreak/><LineBreak/>
+        此外，您通常再也不会看到红色的警告提示文本：<Italic><Bold>“Warning: attempt to run Stereoscopic in non-stereo display mode”</Bold></Italic>。<LineBreak/><LineBreak/>
+        <Bold>注意：</Bold> 请记住，禁用或重新启用覆盖层后，您需要重新启动系统。此外，在更新显卡驱动后，这些更改将被撤销。
+    </TextBlock>
+
+    <TextBlock x:Key="EnableGeforceDllHackToolTip" TextWrapping="Wrap" Width="300">
+        在 Windows 10 v.1903 或更高版本上应用 / 撤销针对 Geforce 驱动的修改。<LineBreak/><LineBreak/>
+        若要在立体 3D 模式及较新的 Geforce 驱动下游玩 DirectX 11 游戏，这是必需的。
+    </TextBlock>
+
+    <TextBlock x:Key="DriverStoreToolTip" TextWrapping="Wrap" Width="300">
+        在 Windows 驱动程序存储中搜索 Geforce 驱动位置，并在 Windows 资源管理器中打开该路径。<LineBreak/><LineBreak/>
+        这有助于手动检查 Geforce 文件夹是否成功为管理员用户组授予了权限。
+    </TextBlock>
+
+    <TextBlock x:Key="ShowDriverHackDialogToolTip" TextWrapping="Wrap" Width="300">
+        在应用 / 撤销 Geforce 显卡驱动修改之前显示一个警告对话框。<LineBreak/><LineBreak/>
+        通过此对话框，用户可决定是开始还是取消驱动修改进程。
+    </TextBlock>
+
+    <TextBlock x:Key="EnableWmrFixToolTip" TextWrapping="Wrap" Width="300">
+        修复尝试同时使用 3D Vision 和 Windows Mixed Reality 时发生的崩溃问题。<LineBreak/><LineBreak/>
+        如果您没有 Windows Mixed Reality (WMR) 头显，请勿启用此选项。
+    </TextBlock>
+
+    <TextBlock x:Key="SwapInterleavePatternToolTip" TextWrapping="Wrap" Width="300">
+        为<Bold>被动式 3D 显示器</Bold>反转交错图案 (Interleave pattern)。<LineBreak/><LineBreak/>
+        这能修复左右眼画面反转交换的问题。<LineBreak/><LineBreak/>
+        从技术上讲，此选项将 Windows 注册表项<Italic><Bold>“InterleavePattern0”</Bold></Italic>和<Italic><Bold>“InterleavePattern1”</Bold></Italic>的值设置为<Italic><Bold>0xff00ff00</Bold></Italic>。<LineBreak/><LineBreak/>
+        <Bold>注意：</Bold> 为了防止 Nvidia 驱动覆盖这些注册表项，在 3D 模式下启动游戏时，它们会在长达 120 秒内受到写保护。该保护期结束后或应用程序被关闭时，将自动重新授予写入权限。
+    </TextBlock>
+
+    <TextBlock x:Key="DepthMultiplierToolTip" TextWrapping="Wrap" Width="300">
+        如果您想要突破最大 3D 深度的限制值，请启用此选项（此过程也称为 Depth Hack 深度黑客技术）。此功能对于投影仪特别有用，因为对于它们来说，系统给出的最大 3D 深度通常过低。<LineBreak/><LineBreak/>
+        当您将倍增器设置为大于 1 的值时，Depth Hack 即刻生效。例如，如果将其设为 2，您可以实现两倍的 3D 深度。<LineBreak/><LineBreak/>
+        按照此例，这实际上意味着，如果游玩时将 3D 深度设置为 100%，因为倍增器设置为 2，这实际将等同于 200% 的深度。同理，80% 的 3D 深度将等同于 160%，依此类推。<LineBreak/><LineBreak/>
+        在使用 Depth Hack 时，您可以欺骗 Nvidia 驱动，使其认为您在使用一个比实际小得多的显示器游玩。您可以在下方看到驱动当前检测到的显示器尺寸。英寸数值越小，最大可调的 3D 深度就越大。<LineBreak/><LineBreak/>
+        3D 深度 Hack 会应用到所有显示器配置中，因此您可以均等地为所有显示设备增加最大 3D 深度。
+    </TextBlock>
+    
+    <TextBlock x:Key="OverrideMonitorSizeTooltip" TextWrapping="Wrap" Width="300">
+        这是传递给 Nvidia 驱动的显示器尺寸。数值越小，最大可调的 3D 深度就越大。<LineBreak/><LineBreak/>
+        为了让投影仪获得最佳 3D 深度，建议输入投影幕布的实际尺寸。<LineBreak/><LineBreak/>
+        您可以通过调整“3D 深度倍增器”或改变此“英寸数值”来调节最大 3D 深度。两者相互影响。
+    </TextBlock>
+
+    <TextBlock x:Key="IROutputToolTip" TextWrapping="Wrap" Width="300">
+        设置 3D Vision 红外 (IR) 发射器（俗称 3D Vision 金字塔）的同步方法。<LineBreak/><LineBreak/>
+        <Bold>单红外环境：</Bold> 如果您的环境中没有使用如遥控器等其他红外发射器设备，请选择此选项。这是 Nvidia 推荐的默认设置。<LineBreak/><LineBreak/>
+        <Bold>多红外环境：</Bold> 如果您在环境中使用多个红外设备（如遥控器），请选择此选项。这能确保红外设备间互不干扰。<LineBreak/><LineBreak/>
+        <Bold>3D Vision 局域网环境：</Bold> 如果您的局域网环境中有多个 3D Vision 红外发射器及其他红外设备（如遥控器），请选择此选项。这能确保红外设备间互不干扰。
+    </TextBlock>
+
+    <TextBlock x:Key="StereoRefreshRateToolTip" TextWrapping="Wrap" Width="300">
+        3D Vision 快门眼镜可在 100 Hz 到 120 Hz 不同的快门频率下运行。<LineBreak/><LineBreak/>
+        在此设置游戏时显示器和快门眼镜运行的指定频率。如果您的电脑性能仅够维持游戏内的 100 fps，将频率降低至 100 Hz 将会非常有用。
+    </TextBlock>
+
+    <TextBlock x:Key="ExportedDriverProfileToolTip" TextWrapping="Wrap" Width="300">
+        如果您无法在 GUI 中找到特定驱动设置选项，您仍然可以通过加载先前由 Nvidia Profile Inspector 导出的配置文件来进行设置。请选择一个 .nip 文件。<LineBreak/><LineBreak/> 
+        <Bold>注意：</Bold> 3D Fix Manager 会优先加载导出的配置（.nip 文件），随后再应用 GUI 中定义的驱动设置。因此，GUI 驱动设置的优先级高于导出的配置文件。
+    </TextBlock>
+
+    <!-- Display Profiles ToolTips -->
+
+    <TextBlock x:Key="ChangeDisplayProfileToolTip" TextWrapping="Wrap" Width="300">
+        选择要切换为当前激活状态的显示器配置。<LineBreak/><LineBreak/>  
+        <Bold>注意：</Bold> 您可以在<Bold><Italic>“显示器配置”</Italic></Bold>选项卡中，根据个人喜好单独设置每个配置。
+    </TextBlock>
+
+    <TextBlock x:Key="ShowProfileDialogOnGameStartToolTip" TextWrapping="Wrap" Width="300">
+        如果您禁用此选项，在下次启动游戏时将不再显示该对话框。<LineBreak/><LineBreak/>       
+        <Bold>注意：</Bold> 您可以在<Bold><Italic>“显示器配置”</Italic></Bold>选项卡中重新开启此对话框。
+    </TextBlock>
+
+    <TextBlock x:Key="ShowProfileDialogOnAppStartToolTip" TextWrapping="Wrap" Width="300">
+        如果您禁用此选项，在启动 3D Fix Manager 时将不再显示该对话框。<LineBreak/><LineBreak/>       
+        <Bold>注意：</Bold> 您可以在<Bold><Italic>“显示器配置”</Italic></Bold>选项卡中重新开启此对话框。
+    </TextBlock>
+
+    <TextBlock x:Key="DisplayNameToolTip" TextWrapping="Wrap" Width="300">
+        请从列表中选择一个显示设备，将其关联至此显示器配置。如此一来，当在该显示设备上启动游戏时，将自动选用该配置。<LineBreak/><LineBreak/>
+       <Bold>注意：</Bold> 强烈建议您将所有常用显示器配置都关联至对应的显示设备，以避免在启动游戏时还要手动选择显示器配置。而是让系统自动检测并应用正确的显示器配置。
+    </TextBlock>
+
+    <TextBlock x:Key="DisplayNameToolTip02" TextWrapping="Wrap" Width="300">
+        选择要关联到显示器配置的显示设备。
+    </TextBlock>
+
+    <TextBlock x:Key="MonitorSizeToolTip" TextWrapping="Wrap" Width="300">
+        请设置显示器的实际尺寸（英寸）。<LineBreak/><LineBreak/>
+        只要您启动游戏，该数值即被写入 Windows 注册表，以便实现准确且可调的最大 3D 深度。<LineBreak/><LineBreak/>
+        如果您认为当前最大 3D 深度仍不够，请转到<Bold><Italic>“Nvidia 3D 设置”</Italic></Bold>选项卡并调节“3D 深度倍增器”。通过此项您可以均等地为所有显示设备增加最大 3D 深度。
+    </TextBlock>
+
+    <TextBlock x:Key="ScreenSizeToolTip" TextWrapping="Wrap" Width="300">
+        请设置投影幕布的实际尺寸（英寸）。<LineBreak/><LineBreak/>
+        只要您启动游戏，该数值即被写入 Windows 注册表，以便实现准确且可调的最大 3D 深度。<LineBreak/><LineBreak/>
+        如果您认为当前最大 3D 深度仍不够，请转到<Bold><Italic>“Nvidia 3D 设置”</Italic></Bold>选项卡并调节“3D 深度倍增器”。通过此项您可以均等地为所有显示设备增加最大 3D 深度。
+    </TextBlock>
+
+    <TextBlock x:Key="TvSizeToolTip" TextWrapping="Wrap" Width="300">
+        请设置电视的实际尺寸（英寸）。<LineBreak/><LineBreak/>
+        只要您启动游戏，该数值即被写入 Windows 注册表，以便实现准确且可调的最大 3D 深度。<LineBreak/><LineBreak/>
+        如果您认为当前最大 3D 深度仍不够，请转到<Bold><Italic>“Nvidia 3D 设置”</Italic></Bold>选项卡并调节“3D 深度倍增器”。通过此项您可以均等地为所有显示设备增加最大 3D 深度。
+    </TextBlock>
+
+    <TextBlock x:Key="DisplayTypeToolTip" TextWrapping="Wrap" Width="300">
+        请选择您显示设备所支持的 3D 技术。<LineBreak/><LineBreak/>
+        如果您拥有一台被动式显示器 / 电视，且它仅支持反转行交错技术 (reversed line interlacing) 时，此设置将非常有用。Nvidia 控制面板并未提供此技术的调整选项。<LineBreak/><LineBreak/>
+        此外，无论显卡驱动更新后该项是否丢失，此选项都能确保始终设置了正确的 3D 技术。
+    </TextBlock>
+
+    <TextBlock x:Key="Preferred3dFormatToolTip" TextWrapping="Wrap" Width="320">
+        请选择您偏好的 3D 格式。<LineBreak/><LineBreak/>
+        请注意，3D 格式只能针对 DirectX 11 游戏进行设置。此外，单个游戏必须已安装 3dmigoto 软件封装器 / 3D 修复。
+    </TextBlock>
+
+    <TextBlock x:Key="FramerateLimit2dToolTip" TextWrapping="Wrap" Width="300">
+        在 2D 模式下游戏时，将帧率限制在指定值。<LineBreak/><LineBreak/>
+        <Bold>建议：</Bold> 对于 G-Sync 显示器，将帧率设置在略低于最大刷新率的数值，以防止垂直同步被触发而增加输入延迟。<LineBreak/><LineBreak/>
+        例如，使用 144 Hz 显示器时，您应将 fps 限制设为 142（相差 2 fps）。
+    </TextBlock>
+
+    <TextBlock x:Key="FramerateLimit3dToolTip" TextWrapping="Wrap" Width="300">
+        在 3D 模式下游戏时，将帧率限制在指定值。通过限制帧率，可以显著降低输入延迟。<LineBreak/><LineBreak/>
+        <Bold>建议：</Bold> 对于经过 3D Vision 认证的显示器或 Generic CRT (通用 CRT) 显示设备，您应将帧率设为 <Bold>“1/2 立体刷新率 (1/2 Stereo Refresh Rate)”</Bold>。这样做可以根据显示器的刷新率自动检测并应用帧率限制，通常会限定在 60 fps。<LineBreak/><LineBreak/>        
+        如果使用的是 3DTV Play 或被动式 3D，您应将帧率限制设为 60。
+    </TextBlock>
+
+    <TextBlock x:Key="ScanlineSyncToolTip" TextWrapping="Wrap" Width="600">
+        Scanline Sync（扫描线同步）是 RivaTuner Statistics Server 的一项新功能，它能产生类似开启垂直同步的效果。就像开启垂直同步一样，Scanline Sync 可防止画面撕裂并确保获得稳定清晰的图像。当您的显示器不支持 G-Sync 或 Freesync 时，您应该使用此功能。<LineBreak/><LineBreak/>
+        与开启垂直同步相比，它的优势在于拥有超低的输入延迟。然而它的缺点是：目前 Scanline Sync 并不能在所有游戏以及所有刷新率下完美工作。<LineBreak/><LineBreak/>
+        Scanline Sync 的原理是通过将帧率限制在显示器的刷新率上，同时在屏幕某固定位置产生一条“撕裂线”。您可以通过 Scanline Index（扫描线索引）向下移动该撕裂线，直到它隐藏在垂直消隐区 (VBI) 中。<LineBreak/><LineBreak/> 
+        <Bold>注意：</Bold> 目前已知，Scanline Sync 在 60 Hz 刷新率下的 2D 模式中表现最佳。当使用更高刷新率时，可能会出现间歇性撕裂或撕裂线失控。这取决于单独的游戏或其使用的游戏引擎。<LineBreak/><LineBreak/> 
+        <Bold>重要提示：</Bold> 必须关闭游戏内的垂直同步功能，以使 Scanline Sync 生效。此外，还必须在全局驱动配置中禁用垂直同步。3D Fix Manager 会自动完成关闭全局驱动垂直同步的操作。<LineBreak/><LineBreak/>
+        <Bold>推荐做法：</Bold> 在 3D 模式下，最佳方案是仅在个别有效的修复配置中启用 Scanline Sync。这样您就可以只在真正支持该功能的游戏上使用它。同时，全局驱动配置中的 Scanline Sync 应当被关闭。<LineBreak/><LineBreak/>
+        对于 2D 模式以及不支持 G-Sync/Freesync 的设备，您可以尝试全局启用 Scanline Sync，因为在 2D 模式下其有效运作的机会更高。对于那些在该模式下不起作用的游戏，则可在其修复配置中单独将其禁用。
+    </TextBlock>
+
+    <TextBlock x:Key="ScanlineModeToolTip" TextWrapping="Wrap" Width="600">
+        <Bold>x：</Bold> 将帧率限制为显示器的刷新率，撕裂线位于固定位置。通常您应为 2D 模式选择此选项。<LineBreak/><LineBreak/>
+        <Bold>x2</Bold> 将帧率限制为显示器双倍刷新率，有两条固定位置的撕裂线。这两条撕裂线可向下移动，并且可以将其中一条隐藏在垂直消隐区中。<LineBreak/><LineBreak/>
+        <Bold>x/2：</Bold> 将帧率限制为显示器半数刷新率，撕裂线位于固定位置。通常您应为 3D 模式选择此选项。
+    </TextBlock>
+
+    <TextBlock x:Key="ScanlineIndexToolTip" TextWrapping="Wrap" Width="600">
+        该选项用于移动撕裂线。正数将其向下移动，负数将其向上移动。<LineBreak/><LineBreak/>
+        <Bold>关：</Bold> 禁用 ScanlineSync。若用户在<Bold>“Nvidia 3D 设置”</Bold>选项卡中开启了垂直同步，则系统将重新启用之。<LineBreak/><LineBreak/>
+        <Bold>自动：</Bold> 通过正确的值自动将撕裂线向下移动，直至其隐藏在垂直消隐区中。要系统自动检测到正确的值，您必须首先设定游戏的目标分辨率。
+    </TextBlock>
+
+    <TextBlock x:Key="GameResolution2DToolTip" TextWrapping="Wrap" Width="300">
+        在 2D 模式下以期望的分辨率启动游戏。<LineBreak/><LineBreak/>
+        <Bold>注意：</Bold> 并非所有游戏都支持此功能。您可以查看<Bold><Italic>“安装”</Italic></Bold>选项卡内图标提示里是否包含<Bold><Italic>“分辨率：由显示器配置控制 (Resolution: By Display Profile)”</Italic></Bold>文本，来确定该游戏是否支持。
+    </TextBlock>
+
+    <TextBlock x:Key="GameResolution3DToolTip" TextWrapping="Wrap" Width="300">
+        在 3D 模式下以期望的分辨率启动游戏。<LineBreak/><LineBreak/>
+        <Bold>注意：</Bold> 并非所有游戏都支持此功能。您可以查看<Bold><Italic>“安装”</Italic></Bold>选项卡内图标提示里是否包含<Bold><Italic>“分辨率：由显示器配置控制 (Resolution: By Display Profile)”</Italic></Bold>文本，来确定该游戏是否支持。
+    </TextBlock>
+
+    <TextBlock x:Key="GameResolutionVrToolTip" TextWrapping="Wrap" Width="300">
+        在 3D 模式下以期望的分辨率启动游戏。<LineBreak/><LineBreak/>
+        对于 HelixVision，1920x1080 是推荐的分辨率，因为它能在画质和性能之间取得良好平衡。我们建议不要设置高于 1920x1080 的分辨率，因为在无法明显提升画质的情况下，高分辨率会影响游戏性能。<LineBreak/><LineBreak/>
+        
+        <Bold>注意：</Bold> 并非所有游戏都支持自动设定目标分辨率。您可以查看<Bold><Italic>“启动 (Play)”</Italic></Bold>选项卡内图标提示里是否包含<Bold><Italic>“分辨率：由显示器配置控制 (Resolution: By Display Profile)”</Italic></Bold>文本，来确定该游戏是否支持。
+    </TextBlock>
+
+    <TextBlock x:Key="FramerateLimitVrToolTip" TextWrapping="Wrap" Width="300">
+        在 VR 模式下游玩时，将帧率限制在指定值。<LineBreak/><LineBreak/>
+        
+        我们建议保留预设值<Italic><Bold>“显示器频率一半 (Half Display Frequency)”</Bold></Italic>。
+        根据您的头显，帧率通常会被限制在 40 fps 或 45 fps。
+        开启帧率限制可使游戏在恒定帧率下运行，极大消除卡顿感，确保您能获得尽可能平滑流畅的游戏体验。<LineBreak/><LineBreak/>
+        
+        <Bold>警告：</Bold> 将帧率限制设置为除了<Italic><Bold>“显示器频率一半”</Bold></Italic>之外的其他任何值，都可能导致游戏卡顿。强烈建议不要移除帧率限制器，因为这会导致 VR 应用程序严重掉帧。<LineBreak/><LineBreak/>
+
+        <Bold>注意：</Bold> 如果您的 PC 性能极为强劲，您可能想将帧率限制设为<Italic><Bold>“显示器完整频率 (Full Display Frequency)”</Bold></Italic>。这意味着游戏内的帧率将同步至 VR 头显的刷新率。
+        在您的 PC 足以维持该高帧率的前提下，您将获得超乎顺滑的游戏体验。遗憾的是，即使是顶级 PC 也无法在绝大多数现代游戏中达成此目标，因此该功能在老游戏上更为实用。
+    </TextBlock>
+
+    <TextBlock x:Key="VrScreenSizeToolTip" TextWrapping="Wrap" Width="300">
+       虚拟屏幕的尺寸，单位为英寸。<LineBreak/><LineBreak/>
+       
+       该数值决定了在游戏中将 3D 深度设定至 100% (最大可能值) 时，人眼所感知到的 3D 深度的强弱。较小的屏幕尺寸数值会带来较强烈的感知效果，而较大的数值会减弱这种效果。<LineBreak/><LineBreak/>
+       对于 HelixVision，80 英寸的值是最佳的，即使在 100% 的 3D 深度下，双眼依然感觉舒适。<LineBreak/><LineBreak/>
+        
+       除非您在游玩时经常在多个虚拟屏幕尺寸之间切换，我们建议您保持预设值。
+    </TextBlock>
+
+    <TextBlock x:Key="DesktopResolutionVrToolTip" TextWrapping="Wrap" Width="300">
+        在 VR 模式下启动游戏或启用立体 3D 时，将桌面分辨率设置为目标分辨率。<LineBreak/><LineBreak/>
+        通过此选项，您可以使桌面的分辨率和刷新率与游戏当前的分辨率设置相匹配。其优势是，这让显示设备免于变换频率，使您在最小化游戏时更快。<LineBreak/><LineBreak/>
+        此外，这项功能还对关闭游戏时遭遇黑屏的 Windows 10 用户非常有用。因为 Windows 10 在开启立体 3D 模式的情况下，改变频率回退时存在一些 Bug。
+    </TextBlock>
+
+    <TextBlock x:Key="DesktopResolution2DToolTip" TextWrapping="Wrap" Width="300">
+        在 2D 模式下启动游戏或禁用立体 3D 时，将桌面分辨率设置为目标分辨率。<LineBreak/><LineBreak/>
+        通过此选项，您可以使桌面的分辨率和刷新率与游戏当前的分辨率设置相匹配。其优势是，这让显示设备免于变换频率，使您在最小化游戏时更快。
+        如果可能的话，尽量为 2D 桌面刷新率和 3D 桌面刷新率设置不同数值，以避免遇到 Windows 10 的黑屏 Bug。
+    </TextBlock>
+
+    <TextBlock x:Key="DesktopResolution3DToolTip" TextWrapping="Wrap" Width="300">
+        在 3D 模式下启动游戏或启用立体 3D 时，将桌面分辨率设置为目标分辨率。<LineBreak/><LineBreak/>
+        通过此选项，您可以使桌面的分辨率和刷新率与游戏当前的分辨率设置相匹配。其优势是，这让显示设备免于变换频率，使您在最小化游戏时更快。<LineBreak/><LineBreak/>
+        此外，这项功能还对关闭游戏时遭遇黑屏的 Windows 10 用户非常有用。因为 Windows 10 在开启立体 3D 模式的情况下，改变频率回退时存在一些 Bug。
+    </TextBlock>
+
+    <TextBlock x:Key="DesktopResolutionOnClosingToolTip" TextWrapping="Wrap" Width="300">
+        在关闭该应用程序时，将桌面设置为指定的分辨率。
+    </TextBlock>
+
+    <TextBlock x:Key="DefaultProfileOnStartupToolTip" TextWrapping="Wrap" Width="300">
+        选择在启动应用程序时应当处于激活状态的显示器配置。
+    </TextBlock>
+
+    <TextBlock x:Key="ShowProfileSelectionOnStartupToolTip" TextWrapping="Wrap" Width="300">
+        设置是否在启动应用程序时打开一个对话框窗口，以便您从中选择激活用哪个显示器配置。
+    </TextBlock>
+
+    <TextBlock x:Key="ShowProfileSelectionOnGameStartToolTip" TextWrapping="Wrap" Width="300">
+        设置是否在游戏启动时显示一个对话框窗口，以便您从中选择激活哪个显示器配置。
+    </TextBlock>
+
+    <TextBlock x:Key="AllowDisplayProfileOverrideToolTip" TextWrapping="Wrap" Width="300">
+        禁用此选项后，将不再允许单个修复配置去修改游戏和桌面的分辨率。<LineBreak/><LineBreak/>
+        分辨率将完全受全局显示器配置所主导（如果用户在该处设了选项的话）。
+    </TextBlock>
+
+    <!-- XAML formated ToolTips End -->
+              
+</ResourceDictionary>


### PR DESCRIPTION
Description:
I have completed the Simplified Chinese (zh-CN) translation for 3D Fix Manager. This includes a new XAML resource dictionary with all strings translated accurately for Chinese users.
​Why this is needed:
3D Fix Manager is still a very useful tool for the 3D Vision community in China. Currently, there is no official Chinese support, which makes it difficult for some users to navigate the settings.
​Changes:
​Added StringResources_CN.xaml  to the repository.
​I understand this project hasn't been updated in a while, but I hope this contribution can be merged to help the community. Thank you for this great tool!